### PR TITLE
Fixed issue with copying variable arrays (#76)

### DIFF
--- a/lib/flatten.cpp
+++ b/lib/flatten.cpp
@@ -5669,8 +5669,10 @@ namespace MiniZinc {
                 vd->e(flate);
               } else {
             	if (reallyFlat->e() && reallyFlat->e()->isa<ArrayLit>()) {
-					// need to copy generated variables of an array as well
-					outputVarDecls(env,vdi_copy,follow_id(reallyFlat->id()));
+				// need to copy generated variables of an array as well
+         		  Expression* flate = copy(env,env.cmap,follow_id(reallyFlat->id()));
+	        	  outputVarDecls(env,vdi_copy,flate);
+				  vd->e(flate);
 				}
 
                 vd = follow_id_to_decl(vd->id())->cast<VarDecl>();

--- a/lib/flatten.cpp
+++ b/lib/flatten.cpp
@@ -5668,6 +5668,11 @@ namespace MiniZinc {
                 outputVarDecls(env,vdi_copy,flate);
                 vd->e(flate);
               } else {
+            	if (reallyFlat->e() && reallyFlat->e()->isa<ArrayLit>()) {
+					// need to copy generated variables of an array as well
+					outputVarDecls(env,vdi_copy,follow_id(reallyFlat->id()));
+				}
+
                 vd = follow_id_to_decl(vd->id())->cast<VarDecl>();
                 VarDecl* reallyFlat = vd->flat();
               


### PR DESCRIPTION
At the current HEAD of feature/minisearch, executing, e.g., 

```
minisearch tests/minisearch/regression_tests/golomb_lns.mzn  
```

yields

```
MiniZinc: evaluation error: could not find solution for unknown identifier: 
X_INTRODUCED_1. Don't forget to add all identifiers you use as arguments of sol() in the output statement.
```

With a small fix: 

```
if (reallyFlat->e() && reallyFlat->e()->isa<ArrayLit>()) {
                    // need to copy generated variables of an array as well
                    outputVarDecls(env,vdi_copy,follow_id(reallyFlat->id()));
                }
```

in line 5671 of flatten.cpp, we get the correct results back.
