### PR TITLE
Add the build folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ include/minizinc/parser.tab.hh
 lib/lexer.yy.cpp
 lib/parser.tab.cpp
 core
+build/
 res/
 CMakeCache.txt
 CMakeFiles


### PR DESCRIPTION
When building according to the install instructions, all generated code and binaries will be located in the build folder. I propose adding this folder to the gitignore file because:
- Generated files being in the gitignore is general practice in Git.
- It prevents commit mistakes
- It will make the git icon in my terminal happy green.