### PR TITLE
Fixes warnings generated by Clang

### DIFF
--- a/include/minizinc/ast.hh
+++ b/include/minizinc/ast.hh
@@ -50,7 +50,7 @@ namespace MiniZinc {
 
   class ExpressionSet;
   class ExpressionSetIter;
-  
+
   /// %Location of an expression in the source code
   class Location {
   public:
@@ -66,19 +66,19 @@ namespace MiniZinc {
     unsigned int last_column : 30;
     /// Whether the location was introduced during compilation
     unsigned int is_introduced : 1;
-    
+
     /// Construct empty location
     Location(void);
-    
+
     /// Return string representation
     std::string toString(void) const;
-    
+
     /// Mark as alive for garbage collection
     void mark(void) const;
-    
+
     /// Return location with introduced flag set
     Location introduce(void) const;
-    
+
     /// Location used for un-allocated expressions
     static Location nonalloc;
   };
@@ -122,10 +122,10 @@ namespace MiniZinc {
     void removeCall(const ASTString& id);
     void clear(void);
     void merge(const Annotation& ann);
-    
+
     static Annotation empty;
   };
-  
+
   /// returns the Annotation specified by the string; returns NULL if not exists
   Expression* getAnnotation(const Annotation& ann, std::string str);
 
@@ -220,7 +220,7 @@ namespace MiniZinc {
       // only bit 2 is set
       return (reinterpret_cast<ptrdiff_t>(this) & static_cast<ptrdiff_t>(3)) == 2;
     }
-    
+
     Expression* tag(void) const {
       return reinterpret_cast<Expression*>(reinterpret_cast<ptrdiff_t>(this) |
                                            static_cast<ptrdiff_t>(2));
@@ -232,7 +232,10 @@ namespace MiniZinc {
 
     /// Test if expression is of type \a T
     template<class T> bool isa(void) const {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-undefined-compare"
       if (nullptr==this)
+#pragma clang diagnostic pop
         throw InternalError("isa: nullptr");
       return isUnboxedInt() ? T::eid==E_INTLIT : _id==T::eid;
     }
@@ -271,8 +274,8 @@ namespace MiniZinc {
     template<class T> static const T* dyn_cast(const Expression* e) {
       return e==NULL ? NULL : e->dyn_cast<T>();
     }
-    
-    
+
+
     /// Add annotation \a ann to the expression
     void addAnnotation(Expression* ann);
 
@@ -281,15 +284,15 @@ namespace MiniZinc {
 
     const Annotation& ann(void) const { return isUnboxedInt() ? Annotation::empty : _ann; }
     Annotation& ann(void) { return isUnboxedInt() ? Annotation::empty : _ann; }
-    
+
     /// Return hash value of \a e
     static size_t hash(const Expression* e) {
       return e==NULL ? 0 : e->hash();
     }
-    
+
     /// Check if \a e0 and \a e1 are equal
     static bool equal(const Expression* e0, const Expression* e1);
-    
+
     /// Mark \a e as alive for garbage collection
     static void mark(Expression* e);
   };
@@ -498,7 +501,7 @@ namespace MiniZinc {
              const std::vector<std::vector<Expression*> >& v);
     /// Recompute hash value
     void rehash(void);
-    
+
     /// Access value
     ASTExprVec<Expression> v(void) const { return _v; }
     /// Set value
@@ -576,7 +579,7 @@ namespace MiniZinc {
     /// Allocate
     Generator(const std::vector<VarDecl*>& v,
               Expression* in);
-    
+
   };
   /// \brief A list of generators with one where-expression
   struct Generators {
@@ -609,7 +612,7 @@ namespace MiniZinc {
     void rehash(void);
     /// Whether comprehension is a set
     bool set(void) const;
-    
+
     /// Return number of generators
     int n_generators(void) const;
     /// Return "in" expression for generator \a i
@@ -735,7 +738,7 @@ namespace MiniZinc {
     /// Return operator type
     UnOpType op(void) const;
   };
-  
+
   /// \brief A predicate or function call expression
   class Call : public Expression {
     friend class Expression;
@@ -819,7 +822,7 @@ namespace MiniZinc {
     VarDecl* flat(void) { return _flat() ? _flat()->cast<VarDecl>() : NULL; }
     /// Set flattened version
     void flat(VarDecl* vd);
-    
+
     /// Recompute hash value
     void rehash(void);
     /// Whether variable is toplevel
@@ -839,10 +842,10 @@ namespace MiniZinc {
     /// Set payload
     void payload(int i) { _payload = i; }
   };
-  
+
   class EnvI;
   class CopyMap;
-  
+
   /// \brief %Let expression
   class Let : public Expression {
     friend Expression* copy(EnvI& env, CopyMap& m, Expression* e, bool followIds, bool copyFundecls, bool isFlatModel);
@@ -869,12 +872,12 @@ namespace MiniZinc {
     ASTExprVec<Expression> let_orig(void) const { return _let_orig; }
     /// Access body
     Expression* in(void) const { return _in; }
-    
+
     /// Remember current let bindings
     void pushbindings(void);
     /// Restore previous let bindings
     void popbindings(void);
-    
+
   };
 
   /// \brief Type-inst expression
@@ -896,14 +899,14 @@ namespace MiniZinc {
     TypeInst(const Location& loc,
              const Type& t,
              Expression* domain=NULL);
-    
+
     /// Access ranges
     ASTExprVec<TypeInst> ranges(void) const { return _ranges; }
     /// Access domain
     Expression* domain(void) const { return _domain; }
     //// Set domain
     void domain(Expression* d) { _domain = d; }
-    
+
     /// Set ranges to \a ranges
     void setRanges(const std::vector<TypeInst*>& ranges);
     bool isarray(void) const { return _ranges.size()>0; }
@@ -932,7 +935,7 @@ namespace MiniZinc {
     ItemId iid(void) const {
       return static_cast<ItemId>(_id);
     }
-    
+
     const Location& loc(void) const {
       return _loc;
     }
@@ -982,7 +985,7 @@ namespace MiniZinc {
     template<class T> static const T* dyn_cast(const Item* i) {
       return i==NULL ? NULL : i->dyn_cast<T>();
     }
-    
+
     /// Check if item should be removed
     bool removed(void) const { return _flag_1; }
     /// Set flag to remove item
@@ -1144,7 +1147,7 @@ namespace MiniZinc {
   };
 
   class EnvI;
-  
+
   /// \brief Function declaration item
   class FunctionI : public Item {
   protected:
@@ -1161,7 +1164,7 @@ namespace MiniZinc {
   public:
     /// The identifier of this item type
     static const ItemId iid = II_FUN;
-    
+
     /// Type of builtin expression-valued functions
     typedef Expression* (*builtin_e) (EnvI&, Call*);
     /// Type of builtin int-valued functions
@@ -1205,7 +1208,7 @@ namespace MiniZinc {
     Expression* e(void) const { return _e; }
     /// Set body
     void e(Expression* b) { _e = b; }
-    
+
     /** \brief Compute return type given argument types \a ta
      */
     Type rtype(EnvI& env, const std::vector<Expression*>& ta);
@@ -1310,7 +1313,7 @@ namespace MiniZinc {
         ASTString sum;
         ASTString lin_exp;
         ASTString element;
-	
+
         ASTString show;
         ASTString fix;
         ASTString output;
@@ -1395,10 +1398,10 @@ namespace MiniZinc {
         ASTString set_eq;
         ASTString set_in;
         ASTString set_card;
-        
+
         ASTString introduced_var;
       } ids;
-    
+
       /// Identifiers for Boolean contexts
       struct {
         Id* root;
@@ -1423,7 +1426,7 @@ namespace MiniZinc {
       /// Command line options
       struct { /// basic MiniZinc command line options
         ASTString cmdlineData_str;
-        ASTString cmdlineData_short_str;        
+        ASTString cmdlineData_short_str;
         ASTString datafile_str;
         ASTString datafile_short_str;
         ASTString globalsDir_str;
@@ -1439,8 +1442,8 @@ namespace MiniZinc {
         ASTString no_optimize_alt_str;
         ASTString no_outputOzn_str;
         ASTString no_outputOzn_short_str;
-        ASTString no_typecheck_str;       
-        ASTString newfzn_str;        
+        ASTString no_typecheck_str;
+        ASTString newfzn_str;
         ASTString outputBase_str;
         ASTString outputFznToStdout_str;
         ASTString outputFznToStdout_alt_str;
@@ -1456,15 +1459,15 @@ namespace MiniZinc {
         ASTString verbose_str;
         ASTString verbose_short_str;
         ASTString version_str;
-        ASTString werror_str; 
-        
+        ASTString werror_str;
+
         struct {
           ASTString all_sols_str;
           ASTString fzn_solver_str;
         } solver;
-        
+
       } cli;
-      
+
       /// options strings to find setting in Options map
       struct {
         ASTString cmdlineData;
@@ -1479,7 +1482,7 @@ namespace MiniZinc {
         ASTString instanceCheckOnly;
         ASTString inputFromStdin;
         ASTString model;
-        ASTString newfzn;  
+        ASTString newfzn;
         ASTString noOznOutput;
         ASTString optimize;
         ASTString outputBase;
@@ -1491,22 +1494,22 @@ namespace MiniZinc {
         ASTString typecheck;
         ASTString verbose;
         ASTString werror;
-        
+
         struct {
           ASTString allSols;
           ASTString fzn_solver;
         } solver;
-        
+
       } opts;
-      
+
       /// categories of the command line interface options
       struct {
         ASTString general;
-        ASTString io;        
+        ASTString io;
         ASTString solver;
         ASTString translation;
       } cli_cat;
-      
+
       /// Keep track of allocated integer literals
       UNORDERED_NAMESPACE::unordered_map<IntVal, WeakRef> integerMap;
       /// Keep track of allocated float literals
@@ -1519,7 +1522,7 @@ namespace MiniZinc {
       }
       static const int max_array_size = INT_MAX / 2;
   };
-    
+
   /// Return static instance
   Constants& constants(void);
 

--- a/include/minizinc/options.hh
+++ b/include/minizinc/options.hh
@@ -19,7 +19,7 @@ namespace MiniZinc {
     protected:
       UNORDERED_NAMESPACE::unordered_map<std::string, KeepAlive> _options;
 
-      inline Expression* getParam(const std::string& name) const;
+      Expression* getParam(const std::string& name) const;
 
     public:
       void setIntParam(const std::string& name,   KeepAlive e);

--- a/lib/MIPdomains.cpp
+++ b/lib/MIPdomains.cpp
@@ -54,7 +54,7 @@
 #endif
 
 namespace MiniZinc {
-  
+
   std::vector<double> MIPD__stats( N_POSTs__size );
 
   template<class T>
@@ -76,14 +76,14 @@ namespace MiniZinc {
 	  return result;
   }
 
-  class MIPD {  
+  class MIPD {
   public:
     MIPD(Env* env, bool fV=false) : __env(env) { getEnv(); fVerbose=fV; }
     static bool fVerbose;
     bool MIPdomains() {
       MIPD__stats[ N_POSTs__NSubintvMin ] = 1e100;
       MIPD__stats[ N_POSTs__SubSizeMin ] = 1e100;
-      
+
       if (!registerLinearConstraintDecls())
         return true;
       if (!register__POSTconstraintDecls())    // not declared => no conversions
@@ -98,14 +98,14 @@ namespace MiniZinc {
         printStats(std::cerr);
       return true;
     }
-    
+
   private:
-    
+
     Env* __env=0;
     Env* getEnv() { MZN_MIPD__assert_hard(__env); return __env; }
-    
+
     typedef VarDecl* PVarDecl;
-    
+
     FunctionI *int_lin_eq;
     FunctionI *int_lin_le;
     FunctionI *float_lin_eq;
@@ -113,18 +113,18 @@ namespace MiniZinc {
     FunctionI *int2float;
     FunctionI *lin_exp_int;
     FunctionI *lin_exp_float;
-	
+
   	std::vector<Type> int_lin_eq_t = make_vec(Type::parint(1), Type::varint(1), Type::parint());
     std::vector<Type> float_lin_eq_t = make_vec(Type::parfloat(1), Type::varfloat(1), Type::parfloat());
     std::vector<Type> t_VIVF = make_vec( Type::varint(), Type::varfloat() );
-    
+
 //     double float_lt_EPS_coef__ = 1e-5;
-      
+
     bool registerLinearConstraintDecls()
     {
       EnvI& env = getEnv()->envi();
       GCLock lock;
-      
+
       int_lin_eq = env.orig->matchFn(env, constants().ids.int_.lin_eq, int_lin_eq_t);
       DBGOUT_MIPD ( "  int_lin_eq = " << int_lin_eq );
 //       MZN_MIPD__assert_hard(fi);
@@ -136,7 +136,7 @@ namespace MiniZinc {
 
       lin_exp_int = env.orig->matchFn(env, constants().ids.lin_exp, int_lin_eq_t);
       lin_exp_float = env.orig->matchFn(env, constants().ids.lin_exp, float_lin_eq_t);
-      
+
       if ( !(int_lin_eq&&int_lin_le&&float_lin_eq&&float_lin_le) ) {
         // say something...
         return false;
@@ -178,14 +178,14 @@ namespace MiniZinc {
     std::vector<Type> t_VIAVI = make_vec(Type::varint(), Type::varint(1));
     std::vector<Type> t_VISI = make_vec(Type::varint(), Type::parsetint());
     std::vector<Type> t_VISIVI = make_vec(Type::varint(), Type::parsetint(), Type::varint());
-    
+
   //     std::vector<Type> t_intarray(1);
   //     t_intarray[0] = Type::parint(-1);
-    
+
     typedef UNORDERED_NAMESPACE::unordered_map<FunctionI*, DCT*> M__POSTCallTypes;
     M__POSTCallTypes mCallTypes;             // actually declared in the input
     std::vector<DCT> aCT;         // all possible
-    
+
     // Fails:
   //   DomainCallType a = { NULL, t_VII, RIT_Halfreif, CT_Comparison, CMPT_EQ, VT_Float };
 
@@ -205,16 +205,16 @@ namespace MiniZinc {
 //       boolShort fPropagatedViews=0;
 //       boolShort fPropagatedLargerEqns=0;
     };
-    
+
     std::vector<VarDescr> vVarDescr;
-    
+
     FunctionI *int_le_reif__POST=0, *int_ge_reif__POST=0, *int_eq_reif__POST=0, *int_ne__POST=0,
-      *float_le_reif__POST=0, *float_ge_reif__POST=0, *aux_float_lt_zero_iff_1__POST=0, 
+      *float_le_reif__POST=0, *float_ge_reif__POST=0, *aux_float_lt_zero_iff_1__POST=0,
         *float_eq_reif__POST=0, *float_ne__POST=0,
       *aux_float_eq_zero_if_1__POST=0, *aux_int_le_zero_if_1__POST=0,
         *aux_float_le_zero_if_1__POST=0, *aux_float_lt_zero_if_1__POST=0,
       *equality_encoding__POST=0, *set_in__POST=0, *set_in_reif__POST=0;
-    
+
     bool register__POSTconstraintDecls()
     {
       EnvI& env = getEnv()->envi();
@@ -241,7 +241,7 @@ namespace MiniZinc {
                         aux_float_le_zero_if_1__POST));
       aCT.push_back(DCT("aux_float_lt_zero_if_1__POST", t_VFVIVFF, RIT_Halfreif, CT_Comparison, CMPT_LT_0, VT_Float,
                         aux_float_lt_zero_if_1__POST));
-      
+
       aCT.push_back(DCT("equality_encoding__POST", t_VIAVI, RIT_Static, CT_Encode, CMPT_None, VT_Int, equality_encoding__POST));
       aCT.push_back(DCT("set_in__POST", t_VISI, RIT_Static, CT_SetIn, CMPT_None, VT_Int, set_in__POST));
       aCT.push_back(DCT("set_in_reif__POST", t_VISIVI, RIT_Reif, CT_SetIn, CMPT_None, VT_Int, set_in_reif__POST));
@@ -262,8 +262,8 @@ namespace MiniZinc {
       }
 	  return true;
     }
-    
-    
+
+
     /// Registering all __POST calls' domain-constrained variables
     void register__POSTvariables() {
       EnvI& env = getEnv()->envi();
@@ -335,7 +335,7 @@ namespace MiniZinc {
       }
       MIPD__stats[ N_POSTs__varsDirect ] = vVarDescr.size();
     }
-    
+
     // Should only be called on a newly added variable
     // OR when looking thru all non-touched vars
     /// Checks init expr of a variable
@@ -395,9 +395,9 @@ namespace MiniZinc {
               ++MIPD__stats[ N_POSTs__initexpr1linexp ];
               if ( led.vd[1]->e() )       // no initexpr for initexpr   FAILS  TODO
                 checkInitExpr( led.vd[1] );
-              return true;                // in any case 
+              return true;                // in any case
             }
-          } else 
+          } else
             if ( true )  {                              // check larger views always. OK? TODO
 //             if ( vd->payload()>=0 )  {                      // larger views
             // TODO should be here?
@@ -412,12 +412,12 @@ namespace MiniZinc {
       return false;
     }
 
-    
+
     /// Build var cliques (i.e. of var pairs viewing each other)
     void constructVarViewCliques() {
 //       std::cerr << "  Model: " << std::endl;
 //       debugprint(getEnv()->flat());
-      
+
   //     TAgenda agenda(vVarDescr.size()), agendaNext;
   //     for ( int i=0; i<agenda.size(); ++i )
   //       agenda[i] = i;
@@ -430,14 +430,14 @@ namespace MiniZinc {
 
       MIPD__stats[ N_POSTs__varsInvolved ] = vVarDescr.size();
     }
-    
+
     void propagateViews(bool &fChanges) {
       EnvI& env = getEnv()->envi();
       GCLock lock;
-      
+
       // Iterate thru original 2-variable equalities to mark views:
       Model& mFlat = *getEnv()->flat();
-      
+
       DBGOUT_MIPD ( "  CHECK ALL INITEXPR if they access a touched variable:" );
       for( VarDeclIterator ivd=mFlat.begin_vardecls(); ivd!=mFlat.end_vardecls(); ++ivd ) {
         if ( ivd->removed() )
@@ -447,7 +447,7 @@ namespace MiniZinc {
           if ( checkInitExpr(ivd->e(), true) )
             fChanges = true;
       }
-        
+
       DBGOUT_MIPD ( "  CHECK ALL CONSTRAINTS for 2-var equations:" );
       for( ConstraintIterator ic=mFlat.begin_constraints();
               ic != mFlat.end_constraints(); ++ic ) {
@@ -510,7 +510,7 @@ namespace MiniZinc {
               }
             }
           }
-          else 
+          else
 //             const bool fI2F = (int2float==c->decl());
 //             const bool fIVR = (constants().var_redef==c->decl());
 //             if ( fI2F || fIVR ) {
@@ -537,11 +537,11 @@ namespace MiniZinc {
                                N_POSTs__int2float : N_POSTs__internalvarredef ];
               }
             }
-          
+
         }
       }
     }
-    
+
     /// This vector stores the linear part of a general view
     /// x = <linear part> + rhs
     typedef std::vector<std::pair<VarDecl*, double> > TLinExpLin;
@@ -553,7 +553,7 @@ namespace MiniZinc {
     };
     typedef std::map<TLinExpLin, NViewData> NViewMap;
     NViewMap mNViews;
-    
+
     /// compare to an existing defining linexp, || just add it to the map
     /// adds only touched defined vars
     /// return true iff new linear connection
@@ -565,18 +565,18 @@ namespace MiniZinc {
       VarDecl* vd = pId->decl();
       MZN_MIPD__assert_hard( vd );
       MZN_MIPD__assert_hard( pC->args().size()==3 );
-      
+
       TLinExpLin rhsLin;
-      NViewData nVRest;      
+      NViewData nVRest;
       nVRest.pVarDefined = vd;
       nVRest.rhs = expr2Const( pC->args()[2] );
-      
+
       std::vector<VarDecl*> vars;
       expr2DeclArray( pC->args()[1], vars );
       std::vector<double> coefs;
       expr2Array( pC->args()[0], coefs );
       MZN_MIPD__assert_hard( vars.size()==coefs.size() );
-      
+
       int nVD=0;
       for ( int i=0; i<vars.size(); ++i ) {
 //         MZN_MIPD__assert_hard( 0.0!=std::fabs
@@ -590,7 +590,7 @@ namespace MiniZinc {
       }
       MZN_MIPD__assert_hard( 1>=nVD );
       std::sort( rhsLin.begin(), rhsLin.end() );
-      
+
       // Divide the equation by the 1st coef
       const double coef1 = rhsLin.begin()->second;
       MZN_MIPD__assert_hard( 0.0!=std::fabs( coef1 ) );
@@ -598,7 +598,7 @@ namespace MiniZinc {
       nVRest.rhs /= coef1;
       for ( auto& rhsL : rhsLin )
         rhsL.second /= coef1;
-      
+
       auto it = mNViews.find( rhsLin );
       if ( mNViews.end()!=it ) {
         LinEq2Vars leq;
@@ -613,20 +613,20 @@ namespace MiniZinc {
         if ( vd->payload()>=0 )                     // only touched
           mNViews[ rhsLin ] = nVRest;
       }
-      
+
       return false;
     }
 
     void propagateImplViews(bool &fChanges) {
       EnvI& env = getEnv()->envi();
       GCLock lock;
-      
+
       // TODO
     }
-  
+
     /// Could be better to mark the calls instead:
     UNORDERED_NAMESPACE::unordered_set<Call*> sCallLinEq2, sCallInt2Float, sCallLinEqN;
-    
+
     class TClique : public std::vector<LinEq2Vars> {       // need more info?
     public:
       /// This function takes the 1st variable && relates all to it
@@ -637,7 +637,7 @@ namespace MiniZinc {
     };
     typedef std::vector<TClique> TCLiqueList;
     TCLiqueList aCliques;
-    
+
     /// register a 2-variable lin eq
     /// add it to the var clique, joining the participants' cliques if needed
     void put2VarsConnection( LinEq2Vars& led, bool fCheckinitExpr=true ) {
@@ -682,11 +682,11 @@ namespace MiniZinc {
           clqNew.insert(clqNew.end(), clqOld.begin(), clqOld.end());
           clqOld.clear();                // Can use C++11 move      TODO
           DBGOUT_MIPD ( "    +++ Joining cliques" );
-        }          
+        }
         nMaybeClq = nCliqueAvailable;  // Could mark as 'unused'  TODO
       }
     }
-    
+
     /// Finds a clique variable to which all domain constr are related
     class TCliqueSorter {
       MIPD& mipd;
@@ -701,7 +701,7 @@ namespace MiniZinc {
       typedef UNORDERED_NAMESPACE::unordered_map<VarDecl*, std::pair<double, double> >
         TMapVars;
       TMapVars mRef0, mRef1;   // to the main var 0, 1
-      
+
       class TMatrixVars : public UNORDERED_NAMESPACE::unordered_map<VarDecl*, TMapVars> {
       public:
         /// Check existing connection
@@ -731,7 +731,7 @@ namespace MiniZinc {
           return false;
         }
       };
-      
+
       class LinEqGraph : public TMatrixVars {
       public:
         static double dCoefMin, dCoefMax;
@@ -807,10 +807,10 @@ namespace MiniZinc {
               propagate2(itSrc, itDST, std::make_pair(A1A2, A1B2plusB1), mWhereStore);
             }
           }
-        }        
+        }
       };
       LinEqGraph leg;
-      
+
       TCliqueSorter(MIPD* pm, int iv) : mipd(*pm), iVarStart(iv)  { }
       void doRelate() {
         MZN_MIPD__assert_hard( mipd.vVarDescr[iVarStart].nClique >= 0 );
@@ -823,10 +823,10 @@ namespace MiniZinc {
           << clq.size() << " connections." );
         for ( auto it1=leg.begin(); it1!=leg.end(); ++it1 )
           mipd.vVarDescr[ it1->first->payload() ].fDomainConstrProcessed = true;
-        
+
         // Propagate the 1st var's relations:
         leg.propagate(leg.begin(), mRef0);
-        
+
         // Find a best main variable according to:
         // 1. isInt 2. hasEqEncode 3. abs linFactor to ref0
         varRef1 = leg.begin()->first;
@@ -844,7 +844,7 @@ namespace MiniZinc {
         leg.propagate(leg.find(varRef1), mRef1);
       }
     };  // class TCliqueSorter
-    
+
     /// Build a domain decomposition for a clique
     /// a clique can consist of just 1 var without a clique object
     class DomainDecomp {
@@ -853,7 +853,7 @@ namespace MiniZinc {
       const int iVarStart;
       TCliqueSorter cls;
       SetOfIntvReal sDomain;
-      
+
       DomainDecomp(MIPD* pm, int iv) : mipd(*pm), iVarStart(iv), cls(pm, iv)  {
         sDomain.insert(IntvReal());   // the decomposed domain. Init to +-inf
       }
@@ -866,41 +866,41 @@ namespace MiniZinc {
           cls.varRef1 = mipd.vVarDescr[ iVarStart ].vd;
         // Adding itself:
         cls.mRef1[ cls.varRef1 ] = std::make_pair( 1.0, 0.0 );
-        
+
         int iVarRef1 = cls.varRef1->payload();
         MZN_MIPD__assert_hard ( nClique ==  mipd.vVarDescr[iVarRef1].nClique );
         cls.fRef1HasEqEncode = mipd.vVarDescr[ iVarRef1 ].pEqEncoding;
-        
+
         // First, construct the domain decomposition in any case
 //         projectVariableConstr( cls.varRef1, std::make_pair(1.0, 0.0) );
 //         if ( nClique >= 0 ) {
         for ( auto& iRef1 : cls.mRef1 ) {
           projectVariableConstr( iRef1.first, iRef1.second );
         }
-        
+
         DBGOUT_MIPD( "Clique " << nClique
           << ": main ref var " <<cls.varRef1->id()->str()
           << ", domain dec: " << sDomain );
-        
+
         MZN_MIPD__assert_for_feas( sDomain.size(), "Clique " << nClique
             << ": main ref var " <<cls.varRef1->id()->str()
             << ", domain dec: " << sDomain );
-        
+
         MZN_MIPD__assert_hard( sDomain.checkFiniteBounds() );
         MZN_MIPD__assert_hard( sDomain.checkDisjunctStrict() );
-        
+
         makeRangeDomains();
-        
+
         // Then, use equality_encoding if available
         if ( cls.fRef1HasEqEncode ) {
           syncWithEqEncoding();
-          syncOtherEqEncodings();          
+          syncOtherEqEncodings();
         } else {  // ! cls.fRef1HasEqEncode
           if ( sDomain.size()>=2 )              // need to simplify stuff otherwise
             createDomainFlags();
         }
         implement__POSTs();
-        
+
         // Statistics
         if ( sDomain.size() < MIPD__stats[ N_POSTs__NSubintvMin ] )
           MIPD__stats[ N_POSTs__NSubintvMin ] = sDomain.size();
@@ -908,7 +908,7 @@ namespace MiniZinc {
         if ( sDomain.size() > MIPD__stats[ N_POSTs__NSubintvMax ] )
           MIPD__stats[ N_POSTs__NSubintvMax ] = sDomain.size();
         for ( auto& intv : sDomain ) {
-          const auto nSubSize = intv.right - intv.left;          
+          const auto nSubSize = intv.right - intv.left;
           if ( nSubSize < MIPD__stats[ N_POSTs__SubSizeMin ] )
             MIPD__stats[ N_POSTs__SubSizeMin ] = nSubSize;
           MIPD__stats[ N_POSTs__SubSizeSum ] += nSubSize;
@@ -918,7 +918,7 @@ namespace MiniZinc {
         if ( cls.fRef1HasEqEncode )
           ++MIPD__stats[ N_POSTs__cliquesWithEqEncode ];
       }
-      
+
       /// Project the domain-related constraints of a variable into the clique
       /// Deltas should be scaled but to a minimum of the target's discr
       /// COmparison sense changes on negated vars
@@ -958,11 +958,11 @@ namespace MiniZinc {
               << A << " * " << vd->id()->str() << " + " << B
               << ":  " << sDomain );
           } else {
-            MZN_MIPD__assert_for_feas( 0, 
+            MZN_MIPD__assert_for_feas( 0,
               "Variable " << vd->id()->str()
               << " of type " << vd->type().toString()
               << " has a domain." );
-          }          
+          }
 //           /// Deleting var domain:
 //           vd->ti()->domain( NULL );
         }
@@ -1036,7 +1036,7 @@ namespace MiniZinc {
                       sDomain.cutDeltas( rhsRnd, rhsRnd, delta );
                     break;
                   default:
-                    MZN_MIPD__assert_hard( ( " No other reified cmp type ", 0 ) );
+                    MZN_MIPD__assert_hard_msg( 0, " No other reified cmp type " );
                 }
                 ++MIPD__stats[ ( vd->ti()->type().isint() ) ?
                   N_POSTs__intCmpReif : N_POSTs__floatCmpReif ];
@@ -1067,14 +1067,14 @@ namespace MiniZinc {
               ++MIPD__stats[ N_POSTs__eq_encode ];
               break;
             default:
-              MZN_MIPD__assert_hard( ("Unknown constraint type", 0 ) );
+              MZN_MIPD__assert_hard_msg( 0, "Unknown constraint type" );
           }
         }
         DBGOUT_MIPD( " Clique domain after proj of "
           << A << " * " << vd->id()->str() << " + " << B
           << ":  " << sDomain );
       }
-      
+
       static double rndIfInt( VarDecl* vdTarget, double v ) {
         return vdTarget->type().isint() ? std::round( v ) : v;
       }
@@ -1084,7 +1084,7 @@ namespace MiniZinc {
       static double rndDownIfInt( VarDecl* vdTarget, double v ) {
         return vdTarget->type().isint() ? std::floor( v+1e-8 ) : v;
       }
-      
+
       void makeRangeDomains() {
         auto bnds = sDomain.getBounds();
         for ( auto& iRef1 : cls.mRef1 ) {
@@ -1103,18 +1103,18 @@ namespace MiniZinc {
           setVarDomain( vd, lb0, ub0);
         }
       }
-      
+
       /// tightens element bounds in the existing eq_encoding of varRef1
       /// Can also back-check from there    TODO
       /// And further checks                TODO
       void syncWithEqEncoding() {
       }
-      
+
       /// sync varRef1's eq_encoding with those of other variables
       void syncOtherEqEncodings() {
         // TODO  This could be in the var projection? No, need the final domain
       }
-      
+
       /// if ! eq_encoding, creates a flag for each subinterval in the domain
       /// && constrains sum(flags)==1
       void createDomainFlags() {
@@ -1138,7 +1138,7 @@ namespace MiniZinc {
         addLinConstr( vIntvLB, vVars, CMPT_LE, 0.0 );
         addLinConstr( vIntvUB__, vVars, CMPT_LE, 0.0 );
       }
-      
+
       /// deletes them as well
       void implement__POSTs() {
         auto bnds = sDomain.getBounds();
@@ -1310,16 +1310,16 @@ namespace MiniZinc {
                 // See if any further constraints here?                             TODO
                 break;
               default:
-                MZN_MIPD__assert_hard( ("Unknown constraint type", 0 ) );
+                MZN_MIPD__assert_hard_msg( 0, "Unknown constraint type" );
             }
             pItem->remove();                                       // removing the call
           }
           // removing the eq_encoding call
-          if ( mipd.vVarDescr[ vd->payload() ].pEqEncoding ) 
+          if ( mipd.vVarDescr[ vd->payload() ].pEqEncoding )
             mipd.vVarDescr[ vd->payload() ].pEqEncoding->remove();
         }
       }
-      
+
       /// sets varFlag = || <= sum( intv.varFlag : SS )
       void relateReifFlag( Expression* expFlag, const SetOfIntvReal& SS, EnumReifType nRT=RIT_Reif ) {
         MZN_MIPD__assert_hard( RIT_Reif==nRT || RIT_Halfreif==nRT );
@@ -1378,7 +1378,7 @@ namespace MiniZinc {
           setVarDomain( varFlag, 0.0, 0.0 );
         }
       }
-      
+
       void setVarDomain( VarDecl* vd, double lb, double ub ) {
         // need to check if the new range is in the previous bounds...   TODO
         if ( vd->type().isfloat() ) {
@@ -1396,9 +1396,9 @@ namespace MiniZinc {
   //           nti->domain(newDom);
           vd->ti()->domain(newDom);
         } else
-          MZN_MIPD__assert_hard( ( "Unknown var type ", 0 ) );
+          MZN_MIPD__assert_hard_msg( 0, "Unknown var type " );
       }
-      
+
       VarDecl* addIntVar(double LB, double UB) {
 //         GCLock lock;
         // Cache them? Only location can be different                    TODO
@@ -1408,7 +1408,7 @@ namespace MiniZinc {
         mipd.getEnv()->envi().flat_addItem(new VarDeclI(Location().introduce(),newVar));
         return newVar;
       }
-      
+
       void addLinConstr( std::vector<double>& coefs, std::vector<Expression*>& vars,
                          EnumCmpType nCmpType, double rhs ) {
         std::vector<Expression*> args(3);
@@ -1424,7 +1424,7 @@ namespace MiniZinc {
         }
         MZN_MIPD__assert_hard( coefs.size()==vars.size() );
         MZN_MIPD__assert_hard( CMPT_EQ==nCmpType || CMPT_LE==nCmpType );
-        DBGOUT_MIPD_SELF( // LinEq leq; leq.coefs=coefs; leq.vd=vars; leq.rhs=rhs; 
+        DBGOUT_MIPD_SELF( // LinEq leq; leq.coefs=coefs; leq.vd=vars; leq.rhs=rhs;
           DBGOUT_MIPD__( " ADDING " << ( CMPT_EQ == nCmpType ? "LIN_EQ" : "LIN_LE" )
             << ": [ " );
         for ( auto c : coefs )
@@ -1436,7 +1436,7 @@ namespace MiniZinc {
             DBGOUT_MIPD__( v->dyn_cast<Id>()->str() << ',' );
 //             else if ( v->isa<VarDecl>() )
 //               MZN_MIPD__assert_hard ("addLinConstr: only id's as variables allowed");
-          else 
+          else
             DBGOUT_MIPD__( mipd.expr2Const(v) << ',' );
         }
         DBGOUT_MIPD( " ] " << ( CMPT_EQ == nCmpType ? "== " : "<= " ) << rhs );
@@ -1498,9 +1498,9 @@ namespace MiniZinc {
         nc->decl(fDecl);
         mipd.getEnv()->envi().flat_addItem(new ConstraintI(Location().introduce(), nc));
       }
-      
+
       /// domain / reif set of one variable into that for a!her
-      void convertIntSet( Expression* e, SetOfIntvReal& s, VarDecl* varTarget, 
+      void convertIntSet( Expression* e, SetOfIntvReal& s, VarDecl* varTarget,
                           double A, double B ) {
         MZN_MIPD__assert_hard( A != 0.0 );
         IntSetVal* S = eval_intset( mipd.getEnv()->envi(), e );
@@ -1518,11 +1518,11 @@ namespace MiniZinc {
           );
         }
       }
-      
+
       /// compute the delta for float strict ineq
       double computeDelta( VarDecl* var, VarDecl* varOrig, IntvReal bnds,
                            double A, Call* pCall, int nArg ) {
-        double delta = varOrig->type().isfloat() ? 
+        double delta = varOrig->type().isfloat() ?
           mipd.expr2Const( pCall->args()[nArg] ) * ( bnds.right-bnds.left )
           : std::fabs( A ) ;           // delta should be scaled as well
         if ( var->type().isint() )  // the projected-onto variable
@@ -1530,7 +1530,7 @@ namespace MiniZinc {
         return delta;
       }
     };  // class DomainDecomp
-    
+
     /// Vars without explicit clique still need a decomposition.
     /// Have !iced all __POSTs, set_in's && eq_encode's to it BEFORE
     /// In each clique, relate all vars to one chosen
@@ -1553,7 +1553,7 @@ namespace MiniZinc {
 //         VarDescr& var = vVarDescr[iVar];
         if ( ! vVarDescr[iVar].fDomainConstrProcessed ) {
           try {
-            GCLock lock;      
+            GCLock lock;
             DomainDecomp dd(this, iVar);
             dd.doProcess();
             vVarDescr[iVar].fDomainConstrProcessed = true;
@@ -1579,9 +1579,9 @@ namespace MiniZinc {
       }
       return fRetTrue;
     }
-      
+
     VarDecl* expr2VarDecl(Expression* arg) {
-      
+
       // The requirement to have actual variable objects
       // might be a limitation if more optimizations are done before...
       // Might need to flexibilize this                       TODO
@@ -1595,7 +1595,7 @@ namespace MiniZinc {
       MZN_MIPD__assert_hard(vd);
       return vd;
     }
-      
+
     /// Fills the vector of vardecls && returns the least index of the array
     template <class Array>
     long long expr2DeclArray(Expression* arg, Array& aVD) {
@@ -1605,7 +1605,7 @@ namespace MiniZinc {
         aVD[i] = expr2VarDecl(al->v()[i]);
       return al->min(0);
     }
-    
+
     /// Fills the vector of expressions && returns the least index of the array
     template <class Array>
     long long expr2ExprArray(Expression* arg, Array& aVD) {
@@ -1624,23 +1624,23 @@ namespace MiniZinc {
       } else if (BoolLit* bl = arg->dyn_cast<BoolLit>()) {
         return ( bl->v() );
       } else {
-        MZN_MIPD__assert_hard_msg( 0, 
+        MZN_MIPD__assert_hard_msg( 0,
          "unexpected expression instead of an int/float/bool literal: eid="
           << arg->eid() << " while E_INTLIT=" << Expression::E_INTLIT );
       }
       return 0.0;
     }
-    
+
     template <class Container, class Elem=int, size_t =0>
     void checkOrResize(Container& cnt, size_t sz) {
       cnt.resize(sz);
     }
-    
+
     template <class Elem, size_t N>
     void checkOrResize(std::array<Elem, N>& cnt, size_t sz) {
       MZN_MIPD__assert_hard( cnt.size() == sz );
     }
-    
+
     template <class Array>
     void expr2Array(Expression* arg, Array& vals) {
       ArrayLit* al = eval_array_lit(getEnv()->envi(), arg);
@@ -1653,7 +1653,7 @@ namespace MiniZinc {
         vals[i] = expr2Const(al->v()[i]);
       }
     }
-    
+
     void printStats(std::ostream& os) {
 //       if ( aCliques.empty() )
 //         return;
@@ -1699,7 +1699,7 @@ namespace MiniZinc {
       << MIPD__stats[ N_POSTs__cliquesWithEqEncode ] << " clq eq_encoded ";
 //       << std::flush
       if ( TCliqueSorter::LinEqGraph::dCoefMax > 1.0 )
-        os 
+        os
         << TCliqueSorter::LinEqGraph::dCoefMin
         << "--"
         << TCliqueSorter::LinEqGraph::dCoefMax
@@ -1708,7 +1708,7 @@ namespace MiniZinc {
     }
 
   };  // class MIPD
-  
+
   template <class N> template <class N1>
   void SetOfIntervals<N>::intersect(const SetOfIntervals<N1>& s2) {
     if ( s2.empty() ) {
@@ -1827,7 +1827,7 @@ namespace MiniZinc {
       return false;
     auto bnds = getBounds();
     return bnds.left > Interval<N>::infMinus()
-      && bnds.right < Interval<N>::infPlus();      
+      && bnds.right < Interval<N>::infPlus();
   }
   /// Check there are no useless interval splittings
   template <class N>
@@ -1844,7 +1844,7 @@ namespace MiniZinc {
     }
     return true;
   }
-  
+
   bool MIPD::fVerbose = false;
 
   void MIPdomains(Env& env, bool fVerbose) {
@@ -1854,8 +1854,8 @@ namespace MiniZinc {
       env.flat()->fail(env.envi());
     }
   }
-  
+
   double MIPD::TCliqueSorter::LinEqGraph::dCoefMin = +1e100;
   double MIPD::TCliqueSorter::LinEqGraph::dCoefMax = -1e100;
-  
+
 }  // namespace MiniZinc


### PR DESCRIPTION
Just to make life as a MiniZinc developer a little easier, I propose these few commits to eliminate the excessive amount of warnings generated by Clang. The following problems have been tackled:
- An unused argument warning in MIPdomains. This seemed to be caused by old use of `MZN_MIPD__assert_hard`, which were easily replaced by `MZN_MIPD__assert_hard_msg`.
- `Options::getParam` was declared an inline function, but not defined in the header file. As the actual implementation of this method was not declared inline and the function does not seem critical, the inline keyword is removed from it's declaration.
-  The `isa` function checks if `this` equals the `nullptr`. This should never happen in modern C++ code (_Clang actually states it might treat this statement as being always `false`_), but I assume this check was added for a reason (*Otherwise we might want to consider removing this if statement*). Thus the last commit adds pragma statements to ignore the warnings when this check occurs.

These small changes will make the whole build run without any warnings or errors on at least `clang-700.1.81`