### PR TITLE
Fixes MznSolver constructor compilation error.

### DIFF
--- a/include/minizinc/solver.hh
+++ b/include/minizinc/solver.hh
@@ -90,7 +90,7 @@ namespace MiniZinc {
     Options options_solver;          // currently can create solver object only after flattening
                                      // so unflexible with solver cmdline options  TODO
   public:
-    MznSolver(bool);
+    MznSolver(bool ism2f = false);
     virtual ~MznSolver();
     virtual void addFlattener();
     virtual bool processOptions(int argc, const char** argv);

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -82,7 +82,7 @@ void SolverFactory::destroySI(SolverInstanceBase * pSI) {
   sistorage.erase(it);
 }
 
-MznSolver::MznSolver(bool ism2f = false) : is_mzn2fzn(ism2f) {}
+MznSolver::MznSolver(bool ism2f) : is_mzn2fzn(ism2f) {}
 
 MznSolver::~MznSolver()
 {


### PR DESCRIPTION
Solves problem where the constructor of MznSolver was inexplicitly the default constructor.

```
.../libminizinc/lib/solver.cpp:85:27: 
error: addition of default argument on redeclaration makes this constructor a default constructor
MznSolver::MznSolver(bool ism2f = false) : is_mzn2fzn(ism2f) {}
```