### PR TITLE
Marks builtin redefinitions as STD functions

### DIFF
--- a/include/minizinc/ast.hpp
+++ b/include/minizinc/ast.hpp
@@ -558,7 +558,13 @@ namespace MiniZinc {
               loc.filename == "stdlib.mzn" ||
               loc.filename.endsWith("/stdlib.mzn") ||
               loc.filename == "flatzinc_builtins.mzn" ||
-              loc.filename.endsWith("/flatzinc_builtins.mzn"));
+              loc.filename.endsWith("/flatzinc_builtins.mzn") ||
+              loc.filename == "redefinitions.mzn" ||
+              loc.filename.endsWith("/redefinitions.mzn") ||
+              loc.filename == "redefinitions-2.0.mzn" ||
+              loc.filename.endsWith("/redefinitions-2.0.mzn") ||
+              loc.filename == "redefinitions-2.0.2.mzn" ||
+              loc.filename.endsWith("/redefinitions-2.0.2.mzn"));
   }
 
 }


### PR DESCRIPTION
When using MergeSTD, the flatzinc redefinitions weren't being merged, thus being reported missing in the new model. These files are included by builtins.mzn, and should be marked as part of the STD library.
