### PR TITLE
Fixes include error for the mzn-gecode target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,6 +555,7 @@ if(HAS_GECODE)
     minizinc.cpp
     solvers/gecode/gecode_solverinstance.cpp
     )
+  target_include_directories(mzn-gecode PRIVATE "${GECODE_HOME}/include")
   target_link_libraries(mzn-gecode minizinc_gecode)
 
   INSTALL(TARGETS minizinc_gecode mzn-gecode


### PR DESCRIPTION
This commit adds an additional include directory to the `mzn-gecode` target. Without this include, CMake would return the following error:
```
[ 80%] Building CXX object CMakeFiles/mzn-gecode.dir/minizinc.cpp.o
[ 82%] Building CXX object CMakeFiles/mzn-gecode.dir/solvers/gecode/gecode_solverinstance.cpp.o
In file included from .../libminizinc/solvers/gecode/gecode_solverinstance.cpp:16:
.../libminizinc/include/minizinc/solvers/gecode_solverinstance.hh:16:10: fatal error: 'gecode/kernel.hh' file not found
#include <gecode/kernel.hh>
         ^
1 error generated.
```
This is for CMake 3.4.3 with Apple LLVM version 7.0.2