### PR TITLE
include <cmath> in flatten_internal.hh

### DIFF
--- a/include/minizinc/flatten_internal.hh
+++ b/include/minizinc/flatten_internal.hh
@@ -12,6 +12,8 @@
 #ifndef __MINIZINC_FLATTEN_INTERNAL_HH__
 #define __MINIZINC_FLATTEN_INTERNAL_HH__
 
+#include <cmath>
+
 #include <minizinc/copy.hh>
 #include <minizinc/flatten.hh>
 #include <minizinc/optimize.hh>


### PR DESCRIPTION
Fixes a failure to build with latest GCC. See [the Ubuntu build logs](https://launchpad.net/ubuntu/+source/minizinc/2.0.13+dfsg1-1), where it failed on all architectures due to missing definitions of floor and ceil in this file.