### PR TITLE
Solves compatibility issues with Xcode 8/MacOS Sierra

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 
 # -------------------------------------------------------------------------------------------------------------------
 if(APPLE)
-   SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.7")
+   SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++0x")
    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "${MZN_LIBCPP}")
 endif(APPLE)


### PR DESCRIPTION
The new version of Xcode (Xcode 8, shipped with MacOS Sierra - `10.12`), is incompatible with the `10.7` deployment target set in the current CMakefile. Compiling using the current settings will result in CMake being unable to find the C++11 libraries: `A c++11 compatible C++ standard library is required to build libminizinc.`

The solution proposed by Xcode warnings is to bump the minimal supported version of the OS X binary from `10.7`, which is 5 years old, to `10.9`, which is almost 3 years old. I present this simple solution in this pull request, solving the compilation issues.

Although this change has the downside of disabling compatibility with really old machines, I think it is an important change that should be made to allow for further development of MiniZinc on MacOS, especially since more and more developers will be upgrading their machines over the next couple of months.