### PR TITLE
Bugfix for equality encoding removal

### DIFF
--- a/lib/MIPdomains.cpp
+++ b/lib/MIPdomains.cpp
@@ -324,7 +324,7 @@ namespace MiniZinc {
               DBGOUT_MIPD__ ( "  Call " << *c
                 << ": 1st arg not a VarDecl, removing if eq_encoding..." );
               /// Only allow literals as main argument for equality_encoding
-              if ( equality_encoding__POST==ipct->first );    //  was MZN_MIPD__assert_hard before MZN 2017
+              if ( equality_encoding__POST==ipct->first )    //  was MZN_MIPD__assert_hard before MZN 2017
                 ic->remove();
               continue;                           // ignore this call
             }


### PR DESCRIPTION
Change from assert to an if left a dangling semi-colon as the if
body, making ic->remove() a statement outside the if even though
the visual indentation indicates otherwise. This change ensures
that the visual format of the code matches the semantics.