### PR TITLE
Fico/XPress MIP wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ endif()
 if(DEFINED GUROBI_HOME AND NOT "${GUROBI_HOME} " STREQUAL " ")
   set(HAS_GUROBI TRUE)
 endif()
+if(DEFINED XPRESS_HOME AND NOT "${XPRESS_HOME} " STREQUAL " ")
+  set(HAS_XPRESS TRUE)
+endif()
 if (DEFINED SCIP_DIR AND DEFINED SOPLEX_DIR AND DEFINED ZIMPL_DIR AND NOT "${SCIP_DIR} " STREQUAL " ")
   set(HAS_SCIP TRUE)                     # Can use SCIP w/o ZIMPL too
 endif()
@@ -378,6 +381,30 @@ if(HAS_GUROBI)  # Version 7.5
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)
+endif()
+
+# -------------------------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------------------------
+if(HAS_XPRESS)
+
+	add_library(minizinc_xpress
+    solvers/MIP/MIP_solverinstance.cpp solvers/MIP/MIP_xpress_wrap.cpp include/minizinc/solvers/MIP/MIP_xpress_wrap.hh
+	)
+
+  target_include_directories(minizinc_xpress PRIVATE "${XPRESS_HOME}/include")
+  link_directories("${XPRESS_HOME}/lib")
+  target_link_libraries(minizinc_xpress minizinc xprb xprs ${CMAKE_THREAD_LIBS_INIT})
+
+	add_executable(mzn-xpress minizinc.cpp)
+  target_compile_definitions(mzn-xpress PRIVATE HAS_MIP )
+  target_include_directories(mzn-xpress PRIVATE "${XPRESS_HOME}/include")
+	target_link_libraries(mzn-xpress minizinc_xpress ${CMAKE_THREAD_LIBS_INIT})
+
+  INSTALL(TARGETS minizinc_xpress mzn-xpress
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+
 endif()
 
 # -------------------------------------------------------------------------------------------------------------------

--- a/include/minizinc/solvers/MIP/MIP_wrap.hh
+++ b/include/minizinc/solvers/MIP/MIP_wrap.hh
@@ -108,7 +108,7 @@ class MIP_wrapper {
       double dWallTime = 0.0;
       std::chrono::time_point<std::chrono::steady_clock> dWallTime0;
       double dCPUTime = 0;
-      std::clock_t cCPUTime0 = 0;
+      clock_t cCPUTime0 = 0;
     };      
     Output output;
 

--- a/include/minizinc/solvers/MIP/MIP_wrap.hh
+++ b/include/minizinc/solvers/MIP/MIP_wrap.hh
@@ -108,7 +108,7 @@ class MIP_wrapper {
       double dWallTime = 0.0;
       std::chrono::time_point<std::chrono::steady_clock> dWallTime0;
       double dCPUTime = 0;
-      clock_t cCPUTime0 = 0;
+      std::clock_t cCPUTime0 = 0;
     };      
     Output output;
 

--- a/include/minizinc/solvers/MIP/MIP_xpress_wrap.hh
+++ b/include/minizinc/solvers/MIP/MIP_xpress_wrap.hh
@@ -1,0 +1,69 @@
+/*
+ *  Main authors:
+ *     Karsten Lehmann <karsten@satalia.com>
+ */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef __MIP_XPRESS_WRAPPER_H__
+#define __MIP_XPRESS_WRAPPER_H__
+#include "minizinc/solvers/MIP/MIP_wrap.hh"
+
+#include "xprb_cpp.h"
+#include "xprs.h"
+
+using namespace std;
+using namespace dashoptimization;
+
+class MIP_xpress_wrapper : public MIP_wrapper {
+public:
+  virtual void doAddVars(size_t n, double *obj, double *lb, double *ub,
+                         VarType *vt, string *names);
+  virtual void addRow(int nnz, int *rmatind, double *rmatval, LinConType sense,
+                      double rhs, int mask = MaskConsType_Normal,
+                      string rowName = "");
+  virtual void setObjSense(int s);
+  virtual void solve();
+  virtual void setVarLB(int iVar, double lb);
+  virtual void setVarUB(int iVar, double ub);
+  virtual void setVarBounds(int iVar, double lb, double ub);
+  virtual void addIndicatorConstraint(int iBVar, int bVal, int nnz,
+                                      int *rmatind, double *rmatval,
+                                      LinConType sense, double rhs,
+                                      std::string rowName = "");
+  virtual bool addWarmStart(const std::vector<VarId> &vars,
+                            const std::vector<double> vals);
+
+  virtual int getNCols() {return variables.size();}
+  virtual int getNRows() {return nRows;}
+  virtual double getInfBound() { return XPRB_INFINITY; }
+  virtual const double *getValues() { return output.x; }
+  virtual double getObjValue() { return output.objVal; }
+  virtual double getBestBound() { return output.bestBound; }
+  virtual double getCPUTime() { return output.dCPUTime; }
+  virtual Status getStatus() { return output.status; }
+  virtual string getStatusName() { return output.statusName; }
+  virtual int getNNodes() { return output.nNodes; }
+  virtual int getNOpen() { return output.nOpenNodes; }
+
+  virtual ~MIP_xpress_wrapper() {}
+
+private:
+  XPRBprob problem{};
+  XPRBexpr xpressObj{};
+  vector<XPRBvar> variables{};
+  size_t nRows{0};
+
+  void setUserSolutionCallback();
+  void setOptions();
+  void writeModelIfRequested();
+  int convertConstraintType(LinConType sense);
+  int convertVariableType(VarType varType);
+  int convertObjectiveSense(int s);
+  XPRBctr addConstraint(int nnz, int *rmatind, double *rmatval,
+                        LinConType sense, double rhs, int mask, string rowName);
+};
+
+#endif // __MIP_XPRESS_WRAPPER_H__

--- a/include/minizinc/solvers/MIP/MIP_xpress_wrap.hh
+++ b/include/minizinc/solvers/MIP/MIP_xpress_wrap.hh
@@ -64,6 +64,7 @@ private:
   int convertObjectiveSense(int s);
   XPRBctr addConstraint(int nnz, int *rmatind, double *rmatval,
                         LinConType sense, double rhs, int mask, string rowName);
+  void addDummyConstraint();
 };
 
 #endif // __MIP_XPRESS_WRAPPER_H__

--- a/solvers/MIP/MIP_xpress_wrap.cpp
+++ b/solvers/MIP/MIP_xpress_wrap.cpp
@@ -63,7 +63,7 @@ void MIP_WrapperFactory::printHelp(ostream &os) {
      << "--timeout <N>        stop search after N seconds, if negative, it "
         "will only stop if at least one solution was found"
      << std::endl
-     << "--numSolutions <N>   stop search after N solutions" << std::endl
+     << "-n <N>, --numSolutions <N>   stop search after N solutions" << std::endl
      << "--writeModel <file>  write model to <file>" << std::endl
      << "--writeModelFormat [lp|mps] the file format of the written model(lp "
         "or mps), default: "
@@ -73,7 +73,7 @@ void MIP_WrapperFactory::printHelp(ostream &os) {
      << "--relGap <d>         relative gap |primal-dual|/<solver-dep> to stop, "
         "default: "
      << relGap << std::endl
-     << "--printAllSolutions  print intermediate solution, default: "
+     << "-a, --printAllSolutions  print intermediate solution, default: "
      << printAllSolutions << std::endl
      << std::endl;
 }
@@ -83,12 +83,13 @@ bool MIP_WrapperFactory::processOption(int &i, int argc, const char **argv) {
   if (cop.get("--msgLevel", &msgLevel)) {
   } else if (cop.get("--logFile", &logFile)) {
   } else if (cop.get("--timeout", &timeout)) {
-  } else if (cop.get("--numSolutions", &numSolutions)) {
+  } else if (cop.get("-n --numSolutions", &numSolutions)) {
   } else if (cop.get("--writeModel", &writeModelFile)) {
   } else if (cop.get("--writeModelFormat", &writeModelFormat)) {
   } else if (cop.get("--relGap", &relGap)) {
   } else if (cop.get("--absGap", &absGap)) {
-  } else if (string(argv[i]) == "--printAllSolutions") {
+  } else if (string(argv[i]) == "--printAllSolutions" ||
+             string(argv[i]) == "-a") {
     printAllSolutions = true;
   } else
     return false;

--- a/solvers/MIP/MIP_xpress_wrap.cpp
+++ b/solvers/MIP/MIP_xpress_wrap.cpp
@@ -1,0 +1,335 @@
+/*
+ *  main authors:
+ *     Karsten Lehmann <karsten@satalia.com>
+ */
+
+/* this source code form is subject to the terms of the mozilla public
+ * license, v. 2.0. if a copy of the mpl was not distributed with this
+ * file, you can obtain one at http://mozilla.org/mpl/2.0/. */
+
+#include <cmath>
+#include <cstring>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include "minizinc/config.hh"
+#include "minizinc/exception.hh"
+
+#include "minizinc/solvers/MIP/MIP_xpress_wrap.hh"
+#include "minizinc/utils.hh"
+
+class XpressException : public runtime_error {
+public:
+  XpressException(string msg) : runtime_error(" MIP_xpress_wrapper: " + msg) {}
+};
+
+MIP_wrapper *MIP_WrapperFactory::GetDefaultMIPWrapper() {
+  return new MIP_xpress_wrapper;
+}
+
+string MIP_WrapperFactory::getVersion() {
+  ostringstream oss;
+  oss << "  MIP wrapper for FICO Xpress Optimiser";
+  oss << ".  Compiled  " __DATE__ "  " __TIME__;
+  return oss.str();
+}
+
+static int msgLevel = 0;
+static int timeout = 0;
+static int numSolutions = 0;
+static string logFile = "";
+static string writeModelFile = "";
+static string writeModelFormat = "lp";
+static double absGap = 0;
+static double relGap = 0.0001;
+static bool printAllSolutions = false;
+
+void MIP_WrapperFactory::printHelp(ostream &os) {
+  os << "XPRESS MIP wrapper options:" << std::endl
+     << "--msgLevel <n>       print solver output, default: " << msgLevel
+     << std::endl
+     << "--logFile <file>     log file" << std::endl
+     << "--timeout <N>        stop search after N seconds, if negative, it "
+        "will only stop if at least one solution was found"
+     << std::endl
+     << "--numSolutions <N>   stop search after N solutions" << std::endl
+     << "--writeModel <file>  write model to <file>" << std::endl
+     << "--writeModelFormat [lp|mps] the file format of the written model(lp "
+        "or mps), default: "
+     << writeModelFormat << std::endl
+     << "--absGap <d>         absolute gap |primal-dual| to stop, default: "
+     << absGap << std::endl
+     << "--relGap <d>         relative gap |primal-dual|/<solver-dep> to stop, "
+        "default: "
+     << relGap << std::endl
+     << "--printAllSolutions  print intermediate solution, default: "
+     << printAllSolutions << std::endl
+     << std::endl;
+}
+
+bool MIP_WrapperFactory::processOption(int &i, int argc, const char **argv) {
+  MiniZinc::CLOParser cop(i, argc, argv);
+  if (cop.get("--msgLevel", &msgLevel)) {
+  } else if (cop.get("--logFile", &logFile)) {
+  } else if (cop.get("--timeout", &timeout)) {
+  } else if (cop.get("--numSolutions", &numSolutions)) {
+  } else if (cop.get("--writeModel", &writeModelFile)) {
+  } else if (cop.get("--writeModelFormat", &writeModelFormat)) {
+  } else if (cop.get("--relGap", &relGap)) {
+  } else if (cop.get("--absGap", &absGap)) {
+  } else if (string(argv[i]) == "--printAllSolutions") {
+    printAllSolutions = true;
+  } else
+    return false;
+  return true;
+}
+
+void MIP_xpress_wrapper::setOptions() {
+  XPRSprob xprsProblem = problem.getXPRSprob();
+
+  problem.setMsgLevel(msgLevel);
+
+  XPRSsetlogfile(xprsProblem, logFile.c_str());
+  XPRSsetintcontrol(xprsProblem, XPRS_MAXTIME, timeout);
+  XPRSsetintcontrol(xprsProblem, XPRS_MAXMIPSOL, numSolutions);
+  XPRSsetdblcontrol(xprsProblem, XPRS_MIPABSSTOP, absGap);
+  XPRSsetdblcontrol(xprsProblem, XPRS_MIPRELSTOP, relGap);
+}
+
+static MIP_wrapper::Status convertStatus(int xpressStatus) {
+  switch (xpressStatus) {
+  case XPRB_MIP_OPTIMAL:
+    return MIP_wrapper::Status::OPT;
+  case XPRB_MIP_INFEAS:
+    return MIP_wrapper::Status::UNSAT;
+  case XPRB_MIP_UNBOUNDED:
+    return MIP_wrapper::Status::UNBND;
+  case XPRB_MIP_NO_SOL_FOUND:
+    return MIP_wrapper::Status::UNKNOWN;
+  case XPRB_MIP_NOT_LOADED:
+    return MIP_wrapper::Status::__ERROR;
+  default:
+    return MIP_wrapper::Status::UNKNOWN;
+  }
+}
+
+static string getStatusName(int xpressStatus) {
+  string rt = "Xpress stopped with status: ";
+  switch (xpressStatus) {
+  case XPRB_MIP_OPTIMAL:
+    return rt + "Optimal";
+  case XPRB_MIP_INFEAS:
+    return rt + "Infeasible";
+  case XPRB_MIP_UNBOUNDED:
+    return rt + "Unbounded";
+  case XPRB_MIP_NO_SOL_FOUND:
+    return rt + "No solution found";
+  case XPRB_MIP_NOT_LOADED:
+    return rt + "No problem loaded or error";
+  default:
+    return rt + "Unknown status";
+  }
+}
+
+static void setOutputVariables(MIP_xpress_wrapper::Output *output,
+                               XPRSprob xprsProblem) {
+  int nCols;
+  XPRSgetintattrib(xprsProblem, XPRS_COLS, &nCols);
+  double *x = (double *)malloc(nCols * sizeof(double));
+  XPRSgetmipsol(xprsProblem, x, NULL);
+  output->x = x;
+
+  int xpressStatus = 0;
+  XPRSgetintattrib(xprsProblem, XPRS_MIPSTATUS, &xpressStatus);
+  output->status = convertStatus(xpressStatus);
+  output->statusName = getStatusName(xpressStatus);
+
+  XPRSgetdblattrib(xprsProblem, XPRS_MIPOBJVAL, &output->objVal);
+  XPRSgetdblattrib(xprsProblem, XPRS_BESTBOUND, &output->bestBound);
+
+  XPRSgetintattrib(xprsProblem, XPRS_NODES, &output->nNodes);
+  XPRSgetintattrib(xprsProblem, XPRS_ACTIVENODES, &output->nOpenNodes);
+
+  output->dWallTime = std::chrono::duration<double>(
+                          std::chrono::steady_clock::now() - output->dWallTime0)
+                          .count();
+  output->dCPUTime = double(std::clock() - output->cCPUTime0) / CLOCKS_PER_SEC;
+}
+
+static void XPRS_CC userSolNotifyCallback(XPRSprob xprsProblem, void *userData,
+                                          const char *solname, int status) {
+  MIP_wrapper::CBUserInfo *info = (MIP_wrapper::CBUserInfo *)userData;
+  MIP_xpress_wrapper *wrapper =
+      static_cast<MIP_xpress_wrapper *>(info->wrapper);
+
+  if (status == 0) {
+    throw XpressException("error while processing solution callback");
+  }
+
+  if (status != 1 || status != 2 || status != 3) {
+    return;
+  }
+
+  setOutputVariables(info->pOutput, xprsProblem);
+
+  if (info->solcbfn)
+    (*info->solcbfn)(*info->pOutput, info->ppp);
+}
+
+void MIP_xpress_wrapper::doAddVars(size_t n, double *obj, double *lb,
+                                   double *ub, VarType *vt, string *names) {
+  if (obj == nullptr || lb == nullptr || ub == nullptr || vt == nullptr ||
+      names == nullptr) {
+    throw XpressException("invalid input");
+  }
+  for (size_t i = 0; i < n; ++i) {
+    char *var_name = (char *)names[i].c_str();
+    int var_type = convertVariableType(vt[i]);
+    XPRBvar var = problem.newVar(var_name, var_type, lb[i], ub[i]);
+    variables.push_back(var);
+    xpressObj.setTerm(obj[i], var);
+  }
+}
+
+void MIP_xpress_wrapper::addRow(int nnz, int *rmatind, double *rmatval,
+                                LinConType sense, double rhs, int mask,
+                                string rowName) {
+  addConstraint(nnz, rmatind, rmatval, sense, rhs, mask, rowName);
+}
+
+XPRBctr MIP_xpress_wrapper::addConstraint(int nnz, int *rmatind,
+                                          double *rmatval, LinConType sense,
+                                          double rhs, int mask,
+                                          string rowName) {
+  nRows++;
+  XPRBctr constraint = problem.newCtr(rowName.c_str());
+  for (int i = 0; i < nnz; ++i) {
+    constraint.setTerm(variables[rmatind[i]], rmatval[i]);
+  }
+  constraint.setTerm(rhs);
+
+  if (constraint.setType(convertConstraintType(sense)) == 1) {
+    throw XpressException("error while setting sense of constraint");
+  }
+
+  return constraint;
+}
+
+void MIP_xpress_wrapper::writeModelIfRequested() {
+  int format = XPRB_LP;
+  if (writeModelFormat == "lp") {
+    format = XPRB_LP;
+  } else if (writeModelFormat == "mps") {
+    format = XPRB_MPS;
+  }
+  if (!writeModelFile.empty()) {
+    problem.exportProb(format, writeModelFile.c_str());
+  }
+}
+
+void MIP_xpress_wrapper::solve() {
+  setOptions();
+  writeModelIfRequested();
+  setUserSolutionCallback();
+
+  problem.setObj(xpressObj);
+
+  cbui.pOutput->dWallTime0 = output.dWallTime0 =
+      std::chrono::steady_clock::now();
+  cbui.pOutput->cCPUTime0 = output.dCPUTime = std::clock();
+
+  if (problem.mipOptimize("c") == 1) {
+    throw XpressException("error while solving");
+  }
+
+  setOutputVariables(&output, problem.getXPRSprob());
+}
+
+void MIP_xpress_wrapper::setUserSolutionCallback() {
+  if (!printAllSolutions) {
+    return;
+  }
+
+  XPRSaddcbusersolnotify(problem.getXPRSprob(), userSolNotifyCallback,
+                         (void *)&cbui, 0);
+}
+
+void MIP_xpress_wrapper::setObjSense(int s) {
+  problem.setSense(convertObjectiveSense(s));
+}
+
+void MIP_xpress_wrapper::setVarLB(int iVar, double lb) {
+  variables[iVar].setLB(lb);
+}
+
+void MIP_xpress_wrapper::setVarUB(int iVar, double ub) {
+  variables[iVar].setUB(ub);
+}
+
+void MIP_xpress_wrapper::setVarBounds(int iVar, double lb, double ub) {
+  setVarLB(iVar, lb);
+  setVarUB(iVar, ub);
+}
+
+void MIP_xpress_wrapper::addIndicatorConstraint(int iBVar, int bVal, int nnz,
+                                                int *rmatind, double *rmatval,
+                                                LinConType sense, double rhs,
+                                                string rowName) {
+  if (bVal != 0 && bVal != 1) {
+    throw XpressException("indicator bval not in 0/1");
+  }
+  XPRBctr constraint =
+      addConstraint(nnz, rmatind, rmatval, sense, rhs, 0, rowName);
+  constraint.setIndicator(2 * bVal - 1, variables[iBVar]);
+}
+
+bool MIP_xpress_wrapper::addWarmStart(const std::vector<VarId> &vars,
+                                      const std::vector<double> vals) {
+  XPRBsol warmstart = problem.newSol();
+  for (size_t ii = 0; ii < vars.size(); ii++) {
+    warmstart.setVar(variables[vars[ii]], vals[ii]);
+  }
+  return 1 - problem.addMIPSol(warmstart);
+}
+
+int MIP_xpress_wrapper::convertConstraintType(LinConType sense) {
+  switch (sense) {
+  case MIP_wrapper::LQ:
+    return XPRB_L;
+  case MIP_wrapper::EQ:
+    return XPRB_E;
+  case MIP_wrapper::GQ:
+    return XPRB_G;
+  default:
+    throw XpressException("unkown constraint sense");
+  }
+}
+
+int MIP_xpress_wrapper::convertVariableType(VarType varType) {
+  switch (varType) {
+  case REAL:
+    return XPRB_PL;
+  case INT:
+    return XPRB_UI;
+  case BINARY:
+    return XPRB_BV;
+  default:
+    throw XpressException("unknown variable type");
+  }
+}
+
+int MIP_xpress_wrapper::convertObjectiveSense(int s) {
+  switch (s) {
+  case 1:
+    return XPRB_MAXIM;
+  case -1:
+    return XPRB_MINIM;
+  default:
+    throw XpressException("unknown objective sense");
+  }
+}


### PR DESCRIPTION
implemented:
- adding of variables and constraints, solving and solution return (the absolute basic)
- some options
- user callback to output all solutions
- warmstart
- CMakeFile target -> mzn_xpress

missing:
- option to set arbitrary solver options, Xpress does not seem to support a way to read options from a file 
- cut + lazy callback

I do not really understand how the cut-callbacks should work and what the lazy constraints are doing.