### PR TITLE
Fix definition of `sum_set`

### DIFF
--- a/share/minizinc/std/fzn_sum_set.mzn
+++ b/share/minizinc/std/fzn_sum_set.mzn
@@ -1,3 +1,3 @@
 predicate fzn_sum_set(array[int] of int: vs, array[int] of int: ws,
                       var set of int: x, var int: s) =
-    s == sum(j in index_set(vs)) ( bool2int(j in x) * ws[j] );
+    s == sum(j in index_set(vs)) ( bool2int(vs[j] in x) * ws[j] );


### PR DESCRIPTION
The informal definition says:

```
predicate sum_set(array [int] of int: vs,
                  array [int] of int: ws,
                  var set of int: x,
                  var int: s)

Requires that the sum of the weights ws [ i1 ].. ws [ iN ] equals s ,
where vs [ i1 ].. vs [ iN ] are the elements appearing in set x
```

However the values of `vs` were not taken into account, such as this example shows:

```
include "globals.mzn";

array [1..1] of int: v = [3];
array [1..1] of int: w = [1];
set of int: s = 3..3;

var int: sum;

constraint sum_set(v,w,s,sum);

solve satisfy;
```

Which constraint `sum` to be 0 instead of 1.
