### PR TITLE
Option to pass fzn via stdin instead of temp file

### DIFF
--- a/include/minizinc/process.hh
+++ b/include/minizinc/process.hh
@@ -96,8 +96,8 @@ namespace MiniZinc {
     }
 #else
     void setPipe(int pipe) {
-            _pipe = pipe;
-        }
+      _pipe = pipe;
+    }
 #endif
 
     class PipeStream : public std::ostream {
@@ -134,7 +134,7 @@ namespace MiniZinc {
           if (_input->_pipe == 0) {
             return 0;
           }
-          return write(_input->_pipe, s, n);
+          return ::write(_input->_pipe, s, n);
 #endif
         }
       };
@@ -291,8 +291,8 @@ namespace MiniZinc {
         close(pipes[2][1]);
 
         if (_input != NULL) {
-            _input.setPipe(pipes[0][1]);
-            _input.provide();
+            _input->setPipe(pipes[0][1]);
+            _input->provide();
         }
 
         close(pipes[0][1]);

--- a/include/minizinc/process.hh
+++ b/include/minizinc/process.hh
@@ -72,6 +72,79 @@ namespace MiniZinc {
 
 #endif
 
+  class InputProvider {
+
+  private:
+#ifdef _WIN32
+    HANDLE _h_pipe = nullptr;
+#else
+    int _pipe = 0;
+#endif
+
+  public:
+    InputProvider() : stream(this) {}
+
+    std::ostream* getStream() {
+      return &stream;
+    }
+
+    virtual void provide() {}
+
+#ifdef _WIN32
+    void setHandle(HANDLE h_pipe) {
+      _h_pipe = h_pipe;
+    }
+#else
+    void setPipe(int pipe) {
+            _pipe = pipe;
+        }
+#endif
+
+    class PipeStream : public std::ostream {
+
+    public:
+      explicit PipeStream(InputProvider* input) : std::ostream(new PipeBuf(input)) {}
+
+      class PipeBuf : public std::streambuf {
+
+      public:
+        explicit PipeBuf(InputProvider* input) : _input(input) {}
+
+      protected:
+        std::streamsize xsputn(const char_type* s, std::streamsize n) override {
+          return write(s, n);
+        }
+
+        int_type overflow(int_type ch) override {
+          return write(&ch, 1);
+        }
+
+      private:
+        InputProvider* _input;
+
+        std::streamsize write(const void* s, std::streamsize n) {
+#ifdef _WIN32
+          if (_input->_h_pipe == nullptr) {
+            return 0;
+          }
+          DWORD count;
+          BOOL success = WriteFile(_input->_h_pipe, reinterpret_cast<const char*>(s), n, &count, nullptr);
+          return count;
+#else
+          if (_input->_pipe == 0) {
+            return 0;
+          }
+          return write(_input->_pipe, s, n);
+#endif
+        }
+      };
+    };
+
+  protected:
+    InputProvider::PipeStream stream;
+
+  };
+
   template<class S2O>
   class Process {
   protected:
@@ -79,6 +152,7 @@ namespace MiniZinc {
     S2O* pS2Out;
     int timelimit;
     bool sigint;
+    InputProvider* _input;
 #ifndef _WIN32
     static void handleInterrupt(int signal) {
       if (signal==SIGINT)
@@ -90,8 +164,8 @@ namespace MiniZinc {
     static bool hadTerm;
 #endif
   public:
-    Process(std::vector<std::string>& fzncmd, S2O* pso, int tl, bool si)
-      : _fzncmd(fzncmd), pS2Out(pso), timelimit(tl), sigint(si) {
+    Process(std::vector<std::string>& fzncmd, S2O* pso, int tl, bool si, InputProvider* input)
+        : _fzncmd(fzncmd), pS2Out(pso), timelimit(tl), sigint(si), _input(input) {
       assert( 0!=pS2Out );
     }
     int run(void) {
@@ -173,6 +247,13 @@ namespace MiniZinc {
       // Stop ReadFile from blocking
       CloseHandle(g_hChildStd_OUT_Wr);
       CloseHandle(g_hChildStd_ERR_Wr);
+
+      if (_input != NULL) {
+        _input->setHandle(g_hChildStd_IN_Wr);
+        _input->provide();
+        CloseHandle(g_hChildStd_IN_Wr);
+      }
+
       // Just close the child's in pipe here
       CloseHandle(g_hChildStd_IN_Rd);
       bool doneStdout = false;
@@ -208,6 +289,12 @@ namespace MiniZinc {
         close(pipes[0][0]);
         close(pipes[1][1]);
         close(pipes[2][1]);
+
+        if (_input != NULL) {
+            _input.setPipe(pipes[0][1]);
+            _input.provide();
+        }
+
         close(pipes[0][1]);
 
         fd_set fdset;

--- a/include/minizinc/solvers/fzn_solverinstance.hh
+++ b/include/minizinc/solvers/fzn_solverinstance.hh
@@ -29,6 +29,7 @@ namespace MiniZinc {
     int fzn_time_limit_ms = 0;
     int solver_time_limit_ms = 0;
     bool fzn_sigint = false;
+    bool fzn_use_stdin = false;
 
     bool fzn_needs_paths = false;
     bool fzn_output_passthrough = false;
@@ -62,6 +63,8 @@ namespace MiniZinc {
       void processFlatZinc(void);
 
       void resetSolver(void);
+
+      void printModel(Printer p);
 
     protected:
       Expression* getSolutionValue(Id* id);

--- a/solvers/mzn/mzn_solverinstance.cpp
+++ b/solvers/mzn/mzn_solverinstance.cpp
@@ -185,7 +185,7 @@ namespace MiniZinc {
     int timelimit = opt.mzn_time_limit_ms;
     bool sigint = opt.mzn_sigint;
     Solns2Log s2l(getSolns2Out()->getOutput(), _log);
-    Process<Solns2Log> proc(cmd_line, &s2l, timelimit, sigint);
+    Process<Solns2Log> proc(cmd_line, &s2l, timelimit, sigint, nullptr);
     int exitCode = proc.run();
 
     return exitCode == 0 ? SolverInstance::UNKNOWN : SolverInstance::ERROR;

--- a/solvers/nl/nl_solverinstance.cpp
+++ b/solvers/nl/nl_solverinstance.cpp
@@ -209,7 +209,7 @@ namespace MiniZinc {
       cmd_line.push_back(opt.nl_solver);
       cmd_line.push_back(file_nl);
       cmd_line.push_back("-AMPL");
-      Process<NLSolns2Out> proc(cmd_line, &s2o, 0, true);
+      Process<NLSolns2Out> proc(cmd_line, &s2o, 0, true, nullptr);
       exitStatus = proc.run();
 
       if (exitStatus == 0) {


### PR DESCRIPTION
Adds a flag (--use-stdin) to the MZN-FZN plugin to pass the fzn to a solver directly via stdin instead of writing to a temp file and passing the name of the file