### PR TITLE
replace max by min in size

### DIFF
--- a/share/minizinc/std/fzn_lex_less_bool.mzn
+++ b/share/minizinc/std/fzn_lex_less_bool.mzn
@@ -9,7 +9,7 @@ predicate fzn_lex_less_bool(array[int] of var bool: x,
           int: ux = max(index_set(x)),
           int: ly = min(index_set(y)),
           int: uy = max(index_set(y)),
-          int: size = max(ux - lx, uy - ly),
+          int: size = min(ux - lx, uy - ly),
           array[0..size+1] of var bool: b }
     in
     b[0]


### PR DESCRIPTION
this error appears in maaaaaany files, but as showin in the example below:

---
var bool: a;
var bool: b;
var bool: c;
array[1..1] of var bool: x = [a];
array[1..2] of var bool: y = [b, c];

include "fzn_lex_less_bool.mzn";

constraint fzn_lex_less_bool(x, y);

solve satisfy;
---

We get an "WARNING: undefined result becomes false in Boolean context
(array access out of bounds)" issue with "minizinc -v -s --all-solutions"