### PR TITLE
Fix for cleaner installation of CMake files

### DIFF
--- a/cmake/support/config_export.cmake
+++ b/cmake/support/config_export.cmake
@@ -6,7 +6,7 @@ if(WIN32 AND NOT CYGWIN)
 else()
   set(DEF_INSTALL_CMAKE_DIR lib/cmake)
 endif()
-set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
+set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR}/libminizinc CACHE PATH "Installation directory for CMake files")
 
 if(NOT IS_ABSOLUTE "${INSTALL_CMAKE_DIR}")
   set(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}")


### PR DESCRIPTION
Right now, CMake files are installed into (assuming default prefix and lib directory, see #379) `/usr/lib/cmake` without a top-level directory. This clutters the user's `/usr/lib/cmake` directory. I think it's cleaner to put everything into a top-level `/usr/lib/cmake/libminizinc` directory, like many programs already do.

Of course, everything under the same license as MiniZinc itself.