### PR TITLE
Minor doc-fix for global_cardinality_closed

### DIFF
--- a/share/minizinc/std/global_cardinality_closed.mzn
+++ b/share/minizinc/std/global_cardinality_closed.mzn
@@ -2,7 +2,7 @@ include "fzn_global_cardinality_closed.mzn";
 include "fzn_global_cardinality_closed_reif.mzn";
 
 /** @group globals.counting
-  Requires that the number of occurrences of \p i in \a x is \a counts[\p i].
+  Requires that the number of occurrences of \a cover[\p i] in \a x is \a counts[\p i].
 
   The elements of \a x must take their values from \a cover.
 */

--- a/share/minizinc/std/global_cardinality_closed_fn.mzn
+++ b/share/minizinc/std/global_cardinality_closed_fn.mzn
@@ -1,7 +1,7 @@
 include "global_cardinality_closed.mzn";
 
 /** @group globals.counting
-  Returns an array with number of occurrences of \p i in \a x.
+  Returns an array with number of occurrences of \a cover[\p i] in \a x.
 
   The elements of \a x must take their values from \a cover.
 */


### PR DESCRIPTION
The global cardinality closed constraints erroneously implied that the
values for the cover were index_set(x), when they are in fact form the
cover.