### PR TITLE
Add fix and test for empty enum

### DIFF
--- a/lib/typecheck.cpp
+++ b/lib/typecheck.cpp
@@ -761,7 +761,14 @@ void create_enum_mapper(EnvI& env, Model* m, unsigned int enumId, VarDecl* vd, M
   }
 
   // Create set literal for overall enum
-  auto* rhs = new BinOp(vd->loc(), IntLit::a(1), BOT_DOTDOT, partCardinality.back());
+  Expression* upperBound;
+  if (!partCardinality.empty()) {
+    upperBound = partCardinality.back();
+  } else {
+    // For empty enums, just create 1..0.
+    upperBound = IntLit::a(0);
+  }
+  auto* rhs = new BinOp(vd->loc(), IntLit::a(1), BOT_DOTDOT, upperBound);
   vd->e(rhs);
 
   if (parts.size() > 1) {

--- a/tests/spec/unit/general/test_empty_enum.mzn
+++ b/tests/spec/unit/general/test_empty_enum.mzn
@@ -1,0 +1,9 @@
+/***
+!Test
+expected: !Result
+  solution: !Solution
+***/
+
+enum EmptyEnum;
+EmptyEnum = {  };
+solve satisfy;


### PR DESCRIPTION
Please take a look (ping @guidotack). I'm hoping this might fix issue #443.

I'm not sure whether this is the right fix, but it seems to make the test work and not break any other tests, and I have not tried to actually deeply understand `create_enum_mapper`.

With `git bisect` it looks like the commit introducing the regression on empty enum was 05afaf2e174b29c3993466988f8dc150b09f6638.