### PR TITLE
Fix bug in grammar documentation

### DIFF
--- a/docs/en/grammar.mzn
+++ b/docs/en/grammar.mzn
@@ -35,7 +35,7 @@
 <assign-item> ::= <ident> "=" <expr>
 
 % Constraint items
-<constraint-item> ::= "constraint" <string-annotation> <expr>
+<constraint-item> ::= "constraint" [ <string-annotation> ] <expr>
 
 % Solve item
 <solve-item> ::= "solve" <annotations> "satisfy"


### PR DESCRIPTION
The string annotation of a constraint should be optional, but it was declared as mandatory in the grammar specificaiton.