### PR TITLE
removed bool2int in sum constructs

### DIFF
--- a/share/minizinc/std/fzn_alternative.mzn
+++ b/share/minizinc/std/fzn_alternative.mzn
@@ -3,5 +3,5 @@ include "span.mzn";
 predicate fzn_alternative(var opt int: s0, var int: d0,
                       array[int] of var opt int: s,
                       array[int] of var int: d) =
-          sum(i in index_set(s))(bool2int(occurs(s[i]))) = occurs(s0) /\
+          sum(i in index_set(s))(occurs(s[i])) = occurs(s0) /\
           span(s0,d0,s,d);

--- a/share/minizinc/std/fzn_alternative_reif.mzn
+++ b/share/minizinc/std/fzn_alternative_reif.mzn
@@ -3,5 +3,5 @@ include "span.mzn";
 predicate fzn_alternative_reif(var opt int: s0, var int: d0,
                       array[int] of var opt int: s,
                       array[int] of var int: d, var bool: b) =
-          b <-> ( sum(i in index_set(s))(bool2int(occurs(s[i]))) = occurs(s0) /\
+          b <-> ( sum(i in index_set(s))(occurs(s[i])) = occurs(s0) /\
                   span(s0,d0,s,d) );

--- a/share/minizinc/std/fzn_among.mzn
+++ b/share/minizinc/std/fzn_among.mzn
@@ -1,3 +1,3 @@
 predicate fzn_among(var int: n, array[int] of var int: x, set of int: v) =
-    n == sum(i in index_set(x)) ( bool2int(x[i] in v) );
+    n == sum(i in index_set(x)) ( x[i] in v );
 

--- a/share/minizinc/std/fzn_among_reif.mzn
+++ b/share/minizinc/std/fzn_among_reif.mzn
@@ -1,2 +1,2 @@
 predicate fzn_among_reif(var int: n, array[int] of var int: x, set of int: v, var bool: b) =
-    b <-> ( n == sum(i in index_set(x)) ( bool2int(x[i] in v) ) );
+    b <-> ( n == sum(i in index_set(x)) ( x[i] in v ) );

--- a/share/minizinc/std/fzn_at_least_set.mzn
+++ b/share/minizinc/std/fzn_at_least_set.mzn
@@ -3,5 +3,5 @@
 %-----------------------------------------------------------------------------%
 
 predicate fzn_at_least_set(int: n, array[int] of var set of int: x, set of int: v) =
-    sum(i in index_set(x)) ( bool2int(x[i] == v) ) >= n;
+    sum(i in index_set(x)) ( x[i] == v ) >= n;
 

--- a/share/minizinc/std/fzn_at_least_set_reif.mzn
+++ b/share/minizinc/std/fzn_at_least_set_reif.mzn
@@ -3,5 +3,5 @@
 %-----------------------------------------------------------------------------%
 
 predicate fzn_at_least_set_reif(int: n, array[int] of var set of int: x, set of int: v, var bool: b) =
-    b <-> sum(i in index_set(x)) ( bool2int(x[i] == v) ) >= n;
+    b <-> sum(i in index_set(x)) ( x[i] == v ) >= n;
 

--- a/share/minizinc/std/fzn_at_most_set.mzn
+++ b/share/minizinc/std/fzn_at_most_set.mzn
@@ -3,5 +3,5 @@
 %-----------------------------------------------------------------------------%
 
 predicate fzn_at_most_set(int: n, array[int] of var set of int: x, set of int: v) =
-    sum(i in index_set(x)) ( bool2int(x[i] == v) ) <= n;
+    sum(i in index_set(x)) ( x[i] == v ) <= n;
 

--- a/share/minizinc/std/fzn_at_most_set_reif.mzn
+++ b/share/minizinc/std/fzn_at_most_set_reif.mzn
@@ -3,5 +3,5 @@
 %-----------------------------------------------------------------------------%
 
 predicate fzn_at_most_set_reif(int: n, array[int] of var set of int: x, set of int: v, var bool: b) =
-    b <-> sum(i in index_set(x)) ( bool2int(x[i] == v) ) <= n;
+    b <-> sum(i in index_set(x)) ( x[i] == v ) <= n;
 

--- a/share/minizinc/std/fzn_bin_packing.mzn
+++ b/share/minizinc/std/fzn_bin_packing.mzn
@@ -5,7 +5,7 @@ predicate fzn_bin_packing(int: c,
         int: all_weight = sum(w)
     } in forall( b in lb_array(bin)..ub_array(bin) ) (
         sum(i in index_set(bin)) (
-            w[i] * bool2int(bin[i] != b)
+            w[i] * (bin[i] != b)
         ) >= (all_weight - c)
     );
 

--- a/share/minizinc/std/fzn_bin_packing_capa.mzn
+++ b/share/minizinc/std/fzn_bin_packing_capa.mzn
@@ -7,7 +7,7 @@ predicate fzn_bin_packing_capa(array[int] of int: c,
     /\
       forall( b in index_set(c) ) (
             c[b] >= sum ( i in index_set(bin) ) (
-                w[i] * bool2int( bin[i] = b )
+                w[i] * ( bin[i] = b )
             )
       );
 

--- a/share/minizinc/std/fzn_bin_packing_capa_reif.mzn
+++ b/share/minizinc/std/fzn_bin_packing_capa_reif.mzn
@@ -9,7 +9,7 @@ predicate fzn_bin_packing_capa_reif(array[int] of int: c,
     /\
       forall( assigned_bin in index_set(c) ) (
             c[assigned_bin] >= sum ( i in index_set(bin) ) (
-                w[i] * bool2int( bin[i] = assigned_bin )
+                w[i] * ( bin[i] = assigned_bin )
             )
       ));
 

--- a/share/minizinc/std/fzn_bin_packing_load.mzn
+++ b/share/minizinc/std/fzn_bin_packing_load.mzn
@@ -7,7 +7,7 @@ predicate fzn_bin_packing_load(array[int] of var int: load,
         )
     /\  forall( b in index_set(load) ) (
             load[b] = sum ( i in index_set(bin) ) (
-                w[i] * bool2int( bin[i] = b )
+                w[i] * ( bin[i] = b )
             )
         );
 

--- a/share/minizinc/std/fzn_bin_packing_load_reif.mzn
+++ b/share/minizinc/std/fzn_bin_packing_load_reif.mzn
@@ -9,7 +9,7 @@ predicate fzn_bin_packing_load_reif(array[int] of var int: load,
         )
     /\  forall( assigned_bin in index_set(load) ) (
             load[assigned_bin] = sum ( i in index_set(bin) ) (
-                w[i] * bool2int( bin[i] = assigned_bin )
+                w[i] * ( bin[i] = assigned_bin )
             )
         ) );
 

--- a/share/minizinc/std/fzn_bin_packing_reif.mzn
+++ b/share/minizinc/std/fzn_bin_packing_reif.mzn
@@ -4,7 +4,7 @@ predicate fzn_bin_packing_reif(int: c,
                       var bool: b) =
         b <-> forall( assigned_bin in lb_array(bin)..ub_array(bin) ) (
             c >= sum ( i in index_set(bin) ) (
-                w[i] * bool2int( bin[i] == assigned_bin )
+                w[i] * ( bin[i] == assigned_bin )
             )
         );
 

--- a/share/minizinc/std/fzn_count_eq.mzn
+++ b/share/minizinc/std/fzn_count_eq.mzn
@@ -1,4 +1,4 @@
 predicate fzn_count_eq(array[int] of var int: x, var int: y, var int: c) =
-    c = sum(i in index_set(x)) ( bool2int(x[i] == y) );
+    c = sum(i in index_set(x)) ( x[i] == y );
 
 %-----------------------------------------------------------------------------%

--- a/share/minizinc/std/fzn_cumulative.mzn
+++ b/share/minizinc/std/fzn_cumulative.mzn
@@ -32,7 +32,7 @@ predicate fzn_cumulative_time(array[int] of var int: s,
     } in (
         forall( t in early..late ) (
             b >= sum( i in Tasks ) (
-                bool2int(s[i] <= t /\ t < s[i] + d[i]) * r[i]
+                (s[i] <= t /\ t < s[i] + d[i]) * r[i]
             )
         )
     );
@@ -46,7 +46,7 @@ predicate fzn_cumulative_task(array[int] of var int: s,
     } in (
         forall( j in Tasks ) ( 
             b >= r[j] + sum( i in Tasks where i != j ) ( 
-                bool2int(s[i] <= s[j] /\ s[j] < s[i] + d[i] ) * r[i]
+                (s[i] <= s[j] /\ s[j] < s[i] + d[i] ) * r[i]
             )
         )
     );

--- a/share/minizinc/std/fzn_cumulative_opt.mzn
+++ b/share/minizinc/std/fzn_cumulative_opt.mzn
@@ -32,7 +32,7 @@ predicate fzn_cumulative_opt_time(array[int] of var opt int: s,
     } in (
         forall( t in early..late ) (
             b >= sum( i in Tasks ) (
-                bool2int(occurs(s[i]) /\ deopt(s[i]) <= t /\ t < deopt(s[i]) + d[i]) * r[i]
+                (occurs(s[i]) /\ deopt(s[i]) <= t /\ t < deopt(s[i]) + d[i]) * r[i]
             )
         )
     );
@@ -46,7 +46,7 @@ predicate fzn_cumulative_opt_task(array[int] of var opt int: s,
     } in (
         forall( j in Tasks ) ( occurs(s[j]) -> 
             b >= r[j] + sum( i in Tasks where i != j ) ( 
-                bool2int(occurs(s[i]) /\ deopt(s[i]) <= deopt(s[j]) /\ deopt(s[j]) < deopt(s[i]) + d[i] ) * r[i]
+                (occurs(s[i]) /\ deopt(s[i]) <= deopt(s[j]) /\ deopt(s[j]) < deopt(s[i]) + d[i] ) * r[i]
             )
         )
     );

--- a/share/minizinc/std/fzn_cumulative_opt_reif.mzn
+++ b/share/minizinc/std/fzn_cumulative_opt_reif.mzn
@@ -32,7 +32,7 @@ predicate fzn_cumulative_opt_time_reif(array[int] of var opt int: s,
     } in (
         bb <-> forall( t in early..late ) (
             b >= sum( i in Tasks ) (
-                bool2int(occurs(s[i]) /\ deopt(s[i]) <= t /\ t < deopt(s[i]) + d[i]) * r[i]
+                (occurs(s[i]) /\ deopt(s[i]) <= t /\ t < deopt(s[i]) + d[i]) * r[i]
             )
         )
     );
@@ -46,7 +46,7 @@ predicate fzn_cumulative_opt_task_reif(array[int] of var opt int: s,
     } in (
         bb <-> forall( j in Tasks ) ( occurs(s[j]) -> 
             b >= r[j] + sum( i in Tasks where i != j ) ( 
-                bool2int(occurs(s[i]) /\ deopt(s[i]) <= deopt(s[j]) /\ deopt(s[j]) < deopt(s[i]) + d[i] ) * r[i]
+                (occurs(s[i]) /\ deopt(s[i]) <= deopt(s[j]) /\ deopt(s[j]) < deopt(s[i]) + d[i] ) * r[i]
             )
         )
     );

--- a/share/minizinc/std/fzn_cumulative_reif.mzn
+++ b/share/minizinc/std/fzn_cumulative_reif.mzn
@@ -32,7 +32,7 @@ predicate fzn_cumulative_time_reif(array[int] of var int: s,
     } in (
         bb <-> forall( t in early..late ) (
             b >= sum( i in Tasks ) (
-                bool2int(s[i] <= t /\ t < s[i] + d[i]) * r[i]
+                (s[i] <= t /\ t < s[i] + d[i]) * r[i]
             )
         )
     );
@@ -46,7 +46,7 @@ predicate fzn_cumulative_task_reif(array[int] of var int: s,
     } in (
         bb <-> forall( j in Tasks ) ( 
             b >= r[j] + sum( i in Tasks where i != j ) ( 
-                bool2int(s[i] <= s[j] /\ s[j] < s[i] + d[i] ) * r[i]
+                (s[i] <= s[j] /\ s[j] < s[i] + d[i] ) * r[i]
             )
         )
     );

--- a/share/minizinc/std/fzn_distribute_reif.mzn
+++ b/share/minizinc/std/fzn_distribute_reif.mzn
@@ -4,6 +4,6 @@ predicate fzn_distribute_reif(array[int] of var int: card,
                               var bool: b) =
         b <-> forall (i in index_set(card)) (
             card[i] == sum(j in index_set(base)) (
-                            bool2int(value[i] = base[j])
+                            value[i] = base[j]
                        )
         );

--- a/share/minizinc/std/fzn_exactly_set.mzn
+++ b/share/minizinc/std/fzn_exactly_set.mzn
@@ -3,4 +3,4 @@
 %-----------------------------------------------------------------------------%
 
 predicate fzn_exactly_set(int: n, array[int] of var set of int: x, set of int: v) =
-    n == sum(i in index_set(x)) ( bool2int(x[i] == v) );
+    n == sum(i in index_set(x)) ( x[i] == v );

--- a/share/minizinc/std/fzn_exactly_set_reif.mzn
+++ b/share/minizinc/std/fzn_exactly_set_reif.mzn
@@ -3,4 +3,4 @@
 %-----------------------------------------------------------------------------%
 
 predicate fzn_exactly_set_reif(int: n, array[int] of var set of int: x, set of int: v, var bool: b) =
-    b <-> n == sum(i in index_set(x)) ( bool2int(x[i] == v) );
+    b <-> n == sum(i in index_set(x)) ( x[i] == v );

--- a/share/minizinc/std/fzn_nvalue.mzn
+++ b/share/minizinc/std/fzn_nvalue.mzn
@@ -3,5 +3,5 @@ predicate fzn_nvalue(var int: n, array[int] of var int: x) =
           int: ux = ub_array(x),
     } in
         n == sum(j in lx..ux) (
-            bool2int(exists(i in index_set(x)) ( x[i] = j ))
+            exists(i in index_set(x)) ( x[i] = j )
         );

--- a/share/minizinc/std/fzn_nvalue_reif.mzn
+++ b/share/minizinc/std/fzn_nvalue_reif.mzn
@@ -3,5 +3,5 @@ predicate fzn_nvalue_reif(var int: n, array[int] of var int: x, var bool: b) =
           int: ux = ub_array(x),
     } in b <->
         n == sum(j in lx..ux) (
-            bool2int(exists(i in index_set(x)) ( x[i] = j ))
+            exists(i in index_set(x)) ( x[i] = j )
         );

--- a/share/minizinc/std/fzn_sum_set.mzn
+++ b/share/minizinc/std/fzn_sum_set.mzn
@@ -1,3 +1,3 @@
 predicate fzn_sum_set(array[int] of int: vs, array[int] of int: ws,
                       var set of int: x, var int: s) =
-    s == sum(j in index_set(vs)) ( bool2int(vs[j] in x) * ws[j] );
+    s == sum(j in index_set(vs)) ( (vs[j] in x) * ws[j] );

--- a/share/minizinc/std/fzn_sum_set_reif.mzn
+++ b/share/minizinc/std/fzn_sum_set_reif.mzn
@@ -1,3 +1,3 @@
 predicate fzn_sum_set_reif(array[int] of int: vs, array[int] of int: ws,
                            var set of int: x, var int: s, var bool: b) =
-    b <-> s == sum(j in index_set(vs)) ( bool2int(j in x) * ws[j] );
+    b <-> s == sum(j in index_set(vs)) ( (j in x) * ws[j] );


### PR DESCRIPTION
Regarding issues #477 and #478 I propose to remove bool2int inside sum constructs such that `bool_lin_` predicates can be used.
