### PR TITLE
Fix value_precede_chain for non 1-based array indexes

### DIFF
--- a/share/minizinc/std/fzn_value_precede_chain_int.mzn
+++ b/share/minizinc/std/fzn_value_precede_chain_int.mzn
@@ -7,10 +7,11 @@ predicate fzn_value_precede_chain_int(array[int] of int: T, array[int] of var in
         seq_precede_chain(X)
     else
         let {
+            int: offset = min(index_set(T)) - 1;
             int: l = lb_array(X);
             int: u = ub_array(X);
             array[1.. u -l +1] of int : p
-                = [sum([i | i in index_set(T) where T[i] = j]) | j in l..u];
+                = [sum([i - offset | i in index_set(T) where T[i] = j]) | j in l..u];
             array [int] of var 0..length(T): Y
                 = array1d(index_set(X),[p[X[i]-l+1] | i in index_set(X)]);
         } in seq_precede_chain(Y)

--- a/tests/spec/unit/globals/value_precede_chain/globals_value_precede_chain_int.mzn
+++ b/tests/spec/unit/globals/value_precede_chain/globals_value_precede_chain_int.mzn
@@ -45,5 +45,6 @@ array[1..3] of var 1..4: x ::add_to_output;
 
 constraint value_precede_chain([3, 2, 1], [3, 2, 1]);
 constraint value_precede_chain([4, 3, 2], x);
+constraint value_precede_chain(array1d(5..7, [4, 3, 2]), x);
 solve satisfy;
 output ["x = array1d(1..3, ", show(x), ");\n"];


### PR DESCRIPTION
When the array of values T for value_precede_chain has indexes that
are not 1-based, the original decomposition in the standard library
did not account for this. This change fixes that by introducing an
offset.

Fixes #530
