### PR TITLE
Small fix for neural net constraint

### DIFF
--- a/share/minizinc/std/fzn_neural_net.mzn
+++ b/share/minizinc/std/fzn_neural_net.mzn
@@ -15,7 +15,7 @@ predicate fzn_neural_net(array[int] of var float: inputs,
         forall(i in index_set(outputs))(neuron[output_ids[i]] = outputs[i]) /\
         forall(i in NODE diff INPUTS) (
             let { int: first = first_edge[i];
-                  int: last = if i = max(NODE) then max(index_set(first_edge))
+                  int: last = if i = max(NODE) then max(index_set(EDGE))
                               else first_edge[i+1] - 1 endif;
                   array[int] of var float: ins = [neuron[edge_parent[j]] | j in first..last];
 		              array[int] of float: ws = [ edge_weight[j] | j in first..last ];


### PR DESCRIPTION
The definition of `fzn_neural_net` seems odd by using the last element of `first_edge` instead of `EDGE` for the last neuron.
```
forall(i in NODE diff INPUTS) (
            let { int: first = first_edge[i];
                  int: last = if i = max(NODE) then max(index_set(first_edge))
```
which should be 
```
forall(i in NODE diff INPUTS) (
            let { int: first = first_edge[i];
                  int: last = if i = max(NODE) then max(index_set(EDGE))
```

That might explain why a dummy element is needed according to the documentation:

![image](https://user-images.githubusercontent.com/998075/164528261-7c0b177c-6d3b-4f01-b82f-c1a73a0a47bf.png)

To debug all of that, I've copied the definition of `fzn_neural_net` and added a few traces:
[nn_example_mzn.zip](https://github.com/MiniZinc/libminizinc/files/8534129/nn_example_mzn.zip)
![nn_kodierung](https://user-images.githubusercontent.com/998075/164528615-d4f801d5-33dd-4f02-b5d2-58d1a8b4b633.png)

With the original definition, I get an empty set of parents for the last neuron 
```
Neuron 4 first 3, last 4
Inputs [X_INTRODUCED_0_, X_INTRODUCED_1_], weights [-3.0, 2.0], -2.0
Neuron 5 first 5, last 6
Inputs [X_INTRODUCED_18_, X_INTRODUCED_27_], weights [0.0, 1.0], 1.0
Neuron 6 first 7, last 6
Inputs [], weights [], -1.0
```
whereas the proposed change fixes that:
```
Neuron 4 first 3, last 4
Inputs [X_INTRODUCED_0_, X_INTRODUCED_1_], weights [-3.0, 2.0], -2.0
Neuron 5 first 5, last 6
Inputs [X_INTRODUCED_18_, X_INTRODUCED_27_], weights [0.0, 1.0], 1.0
Neuron 6 first 7, last 8
Inputs [X_INTRODUCED_18_, X_INTRODUCED_27_], weights [2.0, 0.0], -1.0
```

Additionally, it might make sense to pass an array from node ids to `NEURON_TYPE` (e.g., the hidden neurons might use non-linearities but only the output neurons should use LINEAR, or SOFTMAX once it becomes available :-) )

Cheers,
Alex