### PR TITLE
Fix missing return in non-void function

### DIFF
--- a/lib/model.cpp
+++ b/lib/model.cpp
@@ -167,6 +167,7 @@ bool can_increment_type(const Type& t, PossibleBaseTypes pbt) {
     case PBT_I:
       return false;
   }
+  throw InternalError("Invalid BaseType");
 }
 void increment_type(Type& t, PossibleBaseTypes pbt) {
   assert(pbt != PBT_I);


### PR DESCRIPTION
Not returning in a non-void function causes undefined-behavior.

An enum in C++ is not closed, but may have any value of its underlying
type (in this case int).