### PR TITLE
Add <memory> include required for unique_ptr

### DIFF
--- a/include/minizinc/utils.hh
+++ b/include/minizinc/utils.hh
@@ -21,6 +21,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <ratio>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Do no rely on <memory> to be included by some other header file.
Fixes build failures with GCC 12.1.0.

Fixes #583.