### PR TITLE
docs: add documentation for --input-is-flatzinc

### DIFF
--- a/docs/en/command_line.rst
+++ b/docs/en/command_line.rst
@@ -279,7 +279,7 @@ These options control aspects of the MiniZinc compiler.
 
 .. option::  - --input-from-stdin
 
-    Read problem from standard input
+    Read problem from standard input. Use ``--input-is-flatzinc`` when passing FlatZinc code.
 
 .. option::  -I --search-dir
 

--- a/lib/flattener.cpp
+++ b/lib/flattener.cpp
@@ -71,7 +71,8 @@ void Flattener::printHelp(ostream& os) const {
         "globals "
         "in <stdlib>/<dir>, or <dir> when given a absolute or relative path."
      << std::endl
-     << "  -, --input-from-stdin\n    Read problem from standard input" << std::endl
+     << "  -, --input-from-stdin\n    Read problem from standard input. Use --input-is-flatzinc "
+        "when passing FlatZinc code." << std::endl
      << "  -I <dir>, --search-dir <dir>\n    Additionally search for included files in <dir>."
      << std::endl
      << "  -D \"fMIPdomains=true\"\n    Switch on MIPDomain Unification" << std::endl


### PR DESCRIPTION
As discussed in #655 I'd like to add documentation for the previously undocumented cmd line option ``--input-is-flatzinc``. If there's anything I have missed, please let me know.

All the best
Ilja Becker