### PR TITLE
Fixed unsatisfiable test spec for `github681.mzn`

### DIFF
--- a/tests/spec/unit/regression/github_681.mzn
+++ b/tests/spec/unit/regression/github_681.mzn
@@ -3,8 +3,6 @@
 solvers: [gecode]
 expected: !Result
   solution: !Solution
-    arr: [false]
-  solution: !Solution
     arr: [true]
 ***/
 


### PR DESCRIPTION
The existing test spec could not pass as `arr: [false]` was not a solution that satisfied that final constraint