### PR TITLE
file_utils.cpp: add a missing <cstdint> include

### DIFF
--- a/lib/file_utils.cpp
+++ b/lib/file_utils.cpp
@@ -18,6 +18,7 @@
 #include <minizinc/file_utils.hh>
 
 #include <algorithm>
+#include <cstdint>  // Required on some platforms for miniz
 #include <cstring>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Fix building with gcc13