### PR TITLE
`FindGecode.cmake`: fix handling of static Gecode w/ MPFR

### DIFF
--- a/cmake/modules/FindGecode.cmake
+++ b/cmake/modules/FindGecode.cmake
@@ -51,6 +51,14 @@ foreach(GECODE_COMP ${GECODE_COMPONENTS})
   endif()
 endforeach(GECODE_COMP)
 
+if(GECODE_HAS_MPFR)
+  find_package(MPFR)
+  set_target_properties(Gecode::Float PROPERTIES
+                        INTERFACE_LINK_LIBRARIES ${MPFR_LIBRARIES})
+  list(APPEND GECODE_LIBRARY ${MPFR_LIBRARIES})
+  list(APPEND GECODE_TARGETS ${MPFR_LIBRARIES})
+endif()
+
 if(WIN32 AND GECODE_HAS_GIST AND GECODE_STATIC_LIBS)
   find_package(Qt5 QUIET COMPONENTS Core Gui Widgets PrintSupport)
   set_target_properties(Gecode::Gist PROPERTIES
@@ -62,9 +70,6 @@ unset(GECODE_LIB_WIN)
 unset(GECODE_LIB_LOC)
 
 if(GECODE_LIBRARY AND GECODE_HAS_MPFR)
-  find_package(MPFR)
-  list(APPEND GECODE_LIBRARY ${MPFR_LIBRARIES})
-  list(APPEND GECODE_TARGETS ${MPFR_LIBRARIES})
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
The current logic does not work at all, `GECODE_LIBRARY`/`GECODE_TARGETS` are never referenced outside of this file,
and MPFR never gets linked-in, resulting in linker failure.