### PR TITLE
Add include headers in files using symbols defined by them.

### DIFF
--- a/include/minizinc/flatten_internal.hh
+++ b/include/minizinc/flatten_internal.hh
@@ -615,12 +615,17 @@ public:
   std::vector<KeepAlive>& x;
   CmpExpIdx(std::vector<KeepAlive>& x0) : x(x0) {}
   bool operator()(int i, int j) const {
-    if (Expression::equal(x[i](), x[j]())) {
-      return false;
+    const long long int i_idn =
+        Expression::isa<Id>(x[i]()) ? Expression::cast<Id>(x[i]())->idn() : -1;
+    const long long int j_idn =
+        Expression::isa<Id>(x[j]()) ? Expression::cast<Id>(x[j]())->idn() : -1;
+    const bool i_is_valid_id = i_idn != -1;
+    const bool j_is_valid_id = j_idn != -1;
+    if (i_is_valid_id != j_is_valid_id) {
+      return i_is_valid_id > j_is_valid_id;
     }
-    if (Expression::isa<Id>(x[i]()) && Expression::isa<Id>(x[j]()) &&
-        Expression::cast<Id>(x[i]())->idn() != -1 && Expression::cast<Id>(x[j]())->idn() != -1) {
-      return Expression::cast<Id>(x[i]())->idn() < Expression::cast<Id>(x[j]())->idn();
+    if (i_is_valid_id && j_is_valid_id) {
+      return i_idn < j_idn;
     }
     return x[i]() < x[j]();
   }

--- a/include/minizinc/htmlprinter.hh
+++ b/include/minizinc/htmlprinter.hh
@@ -15,6 +15,8 @@
 #include <utility>
 #include <vector>
 
+#include <minizinc/flatten_internal.hh>
+
 namespace MiniZinc {
 
 class Model;

--- a/include/minizinc/statistics.hh
+++ b/include/minizinc/statistics.hh
@@ -12,6 +12,10 @@
 #pragma once
 
 #include <iterator>
+#include <ios>
+
+#include <minizinc/ast.hh>
+#include <minizinc/prettyprinter.hh>
 
 namespace MiniZinc {
 

--- a/lib/parser.yxx
+++ b/lib/parser.yxx
@@ -9,6 +9,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+%code requires {
+#include <minizinc/ast.hh>
+}
+
 %define api.pure
 
 %parse-param {void *parm}
@@ -31,6 +35,8 @@ namespace MiniZinc{ class ParserLocation; }
 
 #define YYMAXDEPTH 10000
 #define YYINITDEPTH 10000
+
+#include <vector>
 
 #include <minizinc/parser.hh>
 #include <minizinc/file_utils.hh>


### PR DESCRIPTION
Those still compile in most environments since the symbols get imported transitively, but relying on that is considered a bad practice.

It is also necessary to compile MiniZinc with Bazel.