### PR TITLE
Use assignment operator of std::vector to copy the entire vector in o…

### DIFF
--- a/solvers/gecode/fzn_space.cpp
+++ b/solvers/gecode/fzn_space.cpp
@@ -22,12 +22,10 @@ FznSpace::FznSpace(FznSpace& f) : Space(f) {
   for (unsigned int i = 0; i < iv.size(); i++) {
     iv[i].update(*this, f.iv[i]);
   }
-  for (auto&& i : f.ivIntroduced) {
-    ivIntroduced.push_back(i);
-  }
-  for (auto&& i : f.ivDefined) {
-    ivDefined.push_back(i);
-  }
+
+  ivIntroduced = f.ivIntroduced;
+  ivDefined = f.ivDefined;
+  
   if (f.copyAuxVars) {
     IntVarArgs iva;
     for (auto& i : f.ivAux) {
@@ -54,9 +52,7 @@ FznSpace::FznSpace(FznSpace& f) : Space(f) {
     }
     bvAux = BoolVarArray(*this, bva);
   }
-  for (auto&& i : f.bvIntroduced) {
-    bvIntroduced.push_back(i);
-  }
+  bvIntroduced = f.bvIntroduced;
 
 #ifdef GECODE_HAS_SET_VARS
   sv.resize(f.sv.size());
@@ -73,10 +69,8 @@ FznSpace::FznSpace(FznSpace& f) : Space(f) {
     }
     svAux = SetVarArray(*this, sva);
   }
-  for (auto&& i : f.svIntroduced) {
-    svIntroduced.push_back(i);
-  }
-#endif
+
+  svIntroduced = f.svIntroduced;
 
 #ifdef GECODE_HAS_FLOAT_VARS
   fv.resize(f.fv.size());


### PR DESCRIPTION
I am one of the developers working on SPEC CPU's upcoming release. Minizinc is one of the many candidate benchmarks currently being considered for inclusion in the next SPEC CPU release.

As a part of this effort, it was noticed that one of the copy-constructors (for FznSpace) was a key hotspot on x86 systems. The code lines that were showing up as the hotspot were copying of elements of std::vector one-element-at-a-time in a for-loop.

Such "for-loops" were replaced with their equivalent assignment operations and that resulted in ~7% improvement in runtime of the workload (on x86).  I would expect similar gains on other architectures too.

Creating this pull request so that you can review these changes and hopefully accept them. If you have any questions or concerns (or additional suggestions) then would like to hear that as well. 