### PR TITLE
Add include headers in files using symbols defined by them.

### DIFF
--- a/include/minizinc/htmlprinter.hh
+++ b/include/minizinc/htmlprinter.hh
@@ -15,6 +15,8 @@
 #include <utility>
 #include <vector>
 
+#include <minizinc/flatten_internal.hh>
+
 namespace MiniZinc {
 
 class Model;

--- a/include/minizinc/statistics.hh
+++ b/include/minizinc/statistics.hh
@@ -11,8 +11,11 @@
 
 #pragma once
 
+#include <minizinc/ast.hh>
+#include <minizinc/prettyprinter.hh>
 #include <minizinc/warning.hh>
 
+#include <ios>
 #include <iterator>
 #include <memory>
 

--- a/include/minizinc/support/regex.hh
+++ b/include/minizinc/support/regex.hh
@@ -11,15 +11,16 @@
 
 #pragma once
 
-#ifdef HAS_GECODE
-
 // Regex Parser Requirements
 #include <minizinc/astmap.hh>
 #include <minizinc/aststring.hh>
+#include <minizinc/config.hh>
 #include <minizinc/values.hh>
 
 #include <memory>
 #include <set>
+
+#ifdef HAS_GECODE
 
 #include <gecode/minimodel.hh>
 #undef ERROR

--- a/lib/parser.yxx
+++ b/lib/parser.yxx
@@ -9,6 +9,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+%code requires {
+#include <minizinc/ast.hh>
+}
+
 %define api.pure
 
 %parse-param {void *parm}
@@ -31,6 +35,8 @@ namespace MiniZinc{ class ParserLocation; }
 
 #define YYMAXDEPTH 10000
 #define YYINITDEPTH 10000
+
+#include <vector>
 
 #include <minizinc/parser.hh>
 #include <minizinc/file_utils.hh>


### PR DESCRIPTION
Those still compile in most environments since the symbols get imported transitively, but relying on that is considered a bad practice.

It is also necessary to compile MiniZinc with Bazel.

Replaces https://github.com/MiniZinc/libminizinc/pull/850 that was created with the wrong tree.