### PR TITLE
Make the comparator CmpExpIdx respect C++ requirements

### DIFF
--- a/include/minizinc/flatten_internal.hh
+++ b/include/minizinc/flatten_internal.hh
@@ -590,12 +590,17 @@ public:
   std::vector<KeepAlive>& x;
   CmpExpIdx(std::vector<KeepAlive>& x0) : x(x0) {}
   bool operator()(int i, int j) const {
-    if (Expression::equal(x[i](), x[j]())) {
-      return false;
+    const long long int i_idn =
+        Expression::isa<Id>(x[i]()) ? Expression::cast<Id>(x[i]())->idn() : -1;
+    const long long int j_idn =
+        Expression::isa<Id>(x[j]()) ? Expression::cast<Id>(x[j]())->idn() : -1;
+    const bool i_is_valid_id = i_idn != -1;
+    const bool j_is_valid_id = j_idn != -1;
+    if (i_is_valid_id != j_is_valid_id) {
+      return i_is_valid_id > j_is_valid_id;
     }
-    if (Expression::isa<Id>(x[i]()) && Expression::isa<Id>(x[j]()) &&
-        Expression::cast<Id>(x[i]())->idn() != -1 && Expression::cast<Id>(x[j]())->idn() != -1) {
-      return Expression::cast<Id>(x[i]())->idn() < Expression::cast<Id>(x[j]())->idn();
+    if (i_is_valid_id && j_is_valid_id) {
+      return i_idn < j_idn;
     }
     return x[i]() < x[j]();
   }


### PR DESCRIPTION
With the current code, if there are two id Expressions: `id1` and `id2` and one non-id expression `expr`, we could have `id1 < id2` and `id2 < expr < id1`. This CL makes ids to be ordered before non-ids.

Also remove call to Expression::equal(), which also made a checker complain the ordering was not strict, probably because it is not transitive.