### PR TITLE
Fix bug where Mac will fail to parse very small floats

### DIFF
--- a/lib/lexer.lxx
+++ b/lib/lexer.lxx
@@ -16,6 +16,8 @@
 
 %top{
 #include <cstdint>
+#include <cerrno>
+#include <cstdlib>
 }
 
 %{
@@ -101,9 +103,28 @@ namespace MiniZinc {
   }
 
   bool strtofloatval(const char* s, double& v) {
-    std::istringstream iss(s);
-    iss >> v;
-    return !iss.fail();
+    char* endptr;
+    errno = 0;
+    v = std::strtod(s, &endptr);
+    
+    // Check if the entire string was consumed
+    if (*endptr != '\0') {
+      return false;
+    }
+    
+    // Check for overflow or underflow
+    if (errno == ERANGE) {
+      // ERANGE can indicate overflow to infinity or underflow to zero
+      // Both are valid floating point representations, so we accept them
+      return true;
+    }
+    
+    // Any other errno value indicates an error
+    if (errno != 0) {
+      return false;
+    }
+    
+    return true;
   }
 
   void clearBuffer(void* parm) {


### PR DESCRIPTION
Improve Mac/Windows consistency in parsing very small and large floats represented in scientific-notation.

The original "strtofloatval()" function defined in "lib/lexer.lxx" exhibited different behavior on Windows vs Mac. On Windows (Windows 11, Intel) floating point values such as "4.94065645841247e-324" returned "true". On Mac (Sequoia 15.5, M3 Max) the same floating point value returned "false". 

This PR replaces the inconsistent behavior of the original numerical parser "std::istringstream iss(s)" with "std::strtod".
