### PR TITLE
Make the destructor of SolverInstanceBase::Options virtual

### DIFF
--- a/include/minizinc/solver_instance_base.hh
+++ b/include/minizinc/solver_instance_base.hh
@@ -38,6 +38,7 @@ public:
   public:
     bool verbose = false;
     bool printStatistics = false;
+    virtual ~Options() = default;
   };
 
 protected:


### PR DESCRIPTION
This class is a base class for each concrete solver, so this follows the best-practice of making its destructor virtual.