### PR TITLE
Fix compilation of MINIZINC_GC_STATS

### DIFF
--- a/include/minizinc/astmap.hh
+++ b/include/minizinc/astmap.hh
@@ -51,7 +51,7 @@ inline void ManagedASTStringMap<Expression*>::mark() {
     it.first.mark();
     Expression::mark(it.second);
 #if defined(MINIZINC_GC_STATS)
-    GC::stats()[it.second->eid()].keepalive++;
+    GC::stats()[MiniZinc::Expression::eid(it.second)].keepalive++;
 #endif
   }
 }
@@ -61,7 +61,7 @@ inline void ManagedASTStringMap<VarDeclI*>::mark() {
   for (auto& it : *this) {
     it.first.mark();
 #if defined(MINIZINC_GC_STATS)
-    GC::stats()[it.second->e()->Expression::eid()].keepalive++;
+    GC::stats()[MiniZinc::Expression::eid(it.second->e())].keepalive++;
 #endif
     Item::mark(it.second);
   }

--- a/lib/ast.cpp
+++ b/lib/ast.cpp
@@ -1792,7 +1792,7 @@ void Item::mark(Item* item) {
       item->_gcMark = 0;  // need to reset so that Expression::mark works
       Expression::mark(item->cast<VarDeclI>()->e());
 #if defined(MINIZINC_GC_STATS)
-      GC::stats()[item->cast<VarDeclI>()->e()->Expression::eid()].inmodel++;
+      GC::stats()[MiniZinc::Expression::eid(item->cast<VarDeclI>()->e())].inmodel++;
 #endif
       break;
     case Item::II_ASN:
@@ -1803,7 +1803,7 @@ void Item::mark(Item* item) {
     case Item::II_CON:
       Expression::mark(item->cast<ConstraintI>()->e());
 #if defined(MINIZINC_GC_STATS)
-      GC::stats()[item->cast<ConstraintI>()->e()->Expression::eid()].inmodel++;
+      GC::stats()[MiniZinc::Expression::eid(item->cast<ConstraintI>()->e())].inmodel++;
 #endif
       break;
     case Item::II_SOL: {


### PR DESCRIPTION
Hello,
I tried enabling MINIZINC_GC_STATS to print the garbage collector statistics, but the build was failing because of how the method `MiniZinc::Expression::eid` was called in a few places. This pr fixes the build.