### PR TITLE
fixing typo

### DIFF
--- a/share/minizinc/std/diversity.mzn
+++ b/share/minizinc/std/diversity.mzn
@@ -139,7 +139,7 @@ function var int: hamming_distance(array [$A] of var opt $T: x, array [$A] of va
   );
 
 /** @group diversity.distance
-  Returns the Hamming distance between \a x and \a y.
+  Returns the Manhattan distance between \a x and \a y.
 */
 function int: manhattan_distance(array [$A] of $$T: x, array [$A] of $$T: y) =
   assert(


### PR DESCRIPTION
hamming distance references in docs where it should be manhattan distance. section 4.2.7.2, 

Sorry if this is messy its meant to be a response to the issue I raised in the repo. Not sure how to connect them though. I've never contributed before so please let me know if I'm doing things wrong