### PR TITLE
Fix syntax for predicate-item definition

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -17,8 +17,9 @@ Bug fixes:
    called with bool arguments (:bugref:`991`).
 -  Fix a potential crash during type specialisation of calls where a matching
    specialisation already existed.
--  Fix a missed type mismatches of enum types in record and tuple types during
+-  Fix missed type mismatches of enum types in record and tuple types during
    type specialisation. (:bugref:`998`)
+-  Fix syntax for ``predicate-item`` in the FlatZinc grammar specification.
 
 .. _v2.9.5:
 

--- a/docs/en/fzn-grammar.mzn
+++ b/docs/en/fzn-grammar.mzn
@@ -7,7 +7,7 @@
   <solve-item>
 
 % Predicate items
-<predicate-item> ::= "predicate" <identifier> "(" [ <pred-param-type> : <identifier> "," ... ] ")" ";"
+<predicate-item> ::= "predicate" <identifier> "(" [ <pred-param-type> ":" <identifier> "," ... ] ")" ";"
 
 % Identifiers
 <identifier> ::= [A-Za-z][A-Za-z0-9_]*


### PR DESCRIPTION
The ":" separating the parameter type and parameter name should be a literal token. In the rest of the file these tokens are wrapped in quotes.