### PR TITLE
docs: fix Manhattan distance description referencing Hamming distance

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -49,6 +49,8 @@ Bug fixes:
    the FlatZinc output (:bugref:`1011`).
 -  Fix internal error when equating tuples of optional values to absent
    using multipass compilation (:bugref:`1012`).
+-  Fix typo in documentation for the Manhattan distance functions
+   (:bugref:`1000`).
 
 .. _v2.9.5:
 

--- a/share/minizinc/std/diversity.mzn
+++ b/share/minizinc/std/diversity.mzn
@@ -139,7 +139,7 @@ function var int: hamming_distance(array [$A] of var opt $T: x, array [$A] of va
   );
 
 /** @group diversity.distance
-  Returns the Hamming distance between \a x and \a y.
+  Returns the Manhattan distance between \a x and \a y.
 */
 function int: manhattan_distance(array [$A] of $$T: x, array [$A] of $$T: y) =
   assert(
@@ -152,7 +152,7 @@ function int: manhattan_distance(array [$A] of $$T: x, array [$A] of $$T: y) =
   );
 
 /** @group diversity.distance
-  Returns the Hamming distance between \a x and \a y.
+  Returns the Manhattan distance between \a x and \a y.
 */
 function var int: manhattan_distance(array [$A] of var $$T: x, array [$A] of var $$T: y) =
   assert(
@@ -165,7 +165,7 @@ function var int: manhattan_distance(array [$A] of var $$T: x, array [$A] of var
   );
 
 /** @group diversity.distance
-  Returns the Hamming distance between \a x and \a y.
+  Returns the Manhattan distance between \a x and \a y.
 */
 function float: manhattan_distance(array [$A] of float: x, array [$A] of float: y) =
   assert(
@@ -178,7 +178,7 @@ function float: manhattan_distance(array [$A] of float: x, array [$A] of float: 
   );
 
 /** @group diversity.distance
-  Returns the Hamming distance between \a x and \a y.
+  Returns the Manhattan distance between \a x and \a y.
 */
 function var float: manhattan_distance(array [$A] of var float: x, array [$A] of var float: y) =
   assert(


### PR DESCRIPTION
## Summary

The documentation comments for the four `manhattan_distance` function overloads in `share/minizinc/std/diversity.mzn` incorrectly state "Returns the Hamming distance" instead of "Returns the Manhattan distance".

This PR fixes all four instances so the documentation correctly describes the Manhattan distance function.

Closes #1000