### PR TITLE
Fix LE chain compression RHS update

### DIFF
--- a/lib/chain_compressor.cpp
+++ b/lib/chain_compressor.cpp
@@ -576,14 +576,20 @@ void LECompressor::leReplaceVar(Item* i, VarDecl* oldVar, VarDecl* newVar) {
       x[j] = (*al_x)[j];
     }
   }
-  Val d = LinearTraits<Lit>::eval(_env, call->arg(2));
+  Val rhs = LinearTraits<Lit>::eval(_env, call->arg(2));
+  Val d = 0;
 
   simplify_lin<Lit>(coeffs, x, d);
   if (coeffs.empty()) {
-    i->remove();
-    _env.counters.linDel++;
+    if (d > rhs) {
+      _env.fail();
+    } else {
+      i->remove();
+      _env.counters.linDel++;
+    }
     return;
   }
+  rhs -= d;
   std::vector<Expression*> coeffs_e(coeffs.size());
   std::vector<Expression*> x_e(coeffs.size());
   for (unsigned int j = 0; j < coeffs.size(); j++) {
@@ -603,7 +609,7 @@ void LECompressor::leReplaceVar(Item* i, VarDecl* oldVar, VarDecl* newVar) {
   al_x_new->type(al_x->type());
   call->arg(1, al_x_new);
 
-  call->arg(2, Lit::a(d));
+  call->arg(2, Lit::a(rhs));
 
   // Add new occurences
   CollectOccurrencesE ce(_env, _env.varOccurrences, i);

--- a/tests/spec/unit/regression/github_1020.mzn
+++ b/tests/spec/unit/regression/github_1020.mzn
@@ -1,0 +1,18 @@
+/***
+!Test
+solvers: [highs]
+options:
+  -O1: true
+expected: !Result
+  status: SATISFIED
+***/
+
+var 0.0..1000.0: x;
+var 0.0..1000.0: y;
+constraint x = 100.0;
+constraint let {
+  array[0..1] of var bool: a;
+  constraint a[0] -> y <= x;
+  constraint a[1] -> y <= (0.79 * x);
+} in sum(i in 0..1)(a[i]) = 1;
+solve satisfy;


### PR DESCRIPTION
Fixes #1020.

This keeps the original RHS separate from the constant offset removed by `simplify_lin` in `LECompressor::leReplaceVar`, then subtracts that offset from the RHS after simplification.

Regression coverage is added as `tests/spec/unit/regression/github_1020.mzn`.

Tests:
- `pytest spec/unit/regression/github_1020.mzn --driver=<patched minizinc>`
- I ran a portion of the overall suite, but your CI should run the full suite in your build environment