### PR TITLE
Add Xpress solver features: lazy constraints, multiple objectives, user cuts

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -25,6 +25,9 @@ Changes:
    is placed in a kill-on-close job object, so it is reliably terminated
    together with MiniZinc. Several descriptor and handle leaks were fixed in the
    process.
+-  Extend the Xpress solver interface with support for lazy constraints,
+   lexicographic multiple objectives (via the ``goal_hierarchy`` annotation),
+   and user cuts, and enable quadratic and bilinear constraints.
 
 Bug fixes:
 ^^^^^^^^^^

--- a/include/minizinc/_thirdparty/xpress_interface.h
+++ b/include/minizinc/_thirdparty/xpress_interface.h
@@ -28,6 +28,12 @@
 #define XPRS_SOLSTATUS                                               1053
 #define XPRS_NODES                                                   1013
 #define XPRS_ACTIVENODES                                             1015
+#define XPRS_CUTROUNDS                                               1121
+#define XPRS_INPUTCOLS                                               1409
+
+// Per-objective controls (for multi-objective problems)
+#define XPRS_OBJECTIVE_PRIORITY                                      20001
+#define XPRS_OBJECTIVE_WEIGHT                                        20002
 
 // XPRS_SOLSTATUS values
 #define XPRS_SOLSTATUS_NOTFOUND                                      0

--- a/include/minizinc/solvers/MIP/MIP_xpress_wrap.hh
+++ b/include/minizinc/solvers/MIP/MIP_xpress_wrap.hh
@@ -14,9 +14,16 @@
 #include <minizinc/solver_instance_base.hh>
 #include <minizinc/solvers/MIP/MIP_wrap.hh>
 
+#include <memory>
+
 #include <minizinc/_thirdparty/xpress_interface.h>
 
 using namespace std;
+
+// Callback payloads (defined in MIP_xpress_wrap.cpp); held by unique_ptr members below so
+// they outlive the solve and are freed with the wrapper rather than leaked.
+struct UserSolutionCallbackData;
+struct UserCutCallbackData;
 
 class XpressPlugin {
 public:
@@ -92,6 +99,14 @@ public:
                                                           const char* msg, int len, int msgtype),
                                  void* p, int priority);
   // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSremovecbintsol)(XPRSprob prob,
+                                   void(XPRS_CC* f_intsol)(XPRSprob prob, void* vContext), void* p);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSremovecbmessage)(XPRSprob prob,
+                                    void(XPRS_CC* f_message)(XPRSprob prob, void* vContext,
+                                                             const char* msg, int len, int msgtype),
+                                    void* p);
+  // NOLINTNEXTLINE(readability-identifier-naming)
   int(XPRS_CC* XPRSgetcontrolinfo)(XPRSprob prob, const char* sCaName, int* iHeaderId,
                                    int* iTypeinfo);
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -114,8 +129,34 @@ public:
   int(XPRS_CC* XPRSaddindicators)(XPRSprob prob, int nrows, const int rowind[], const int colind[],
                                   const int complement[]);
   // NOLINTNEXTLINE(readability-identifier-naming)
-  int(XPRS_CC* XPRSaddqmatrix)(XPRSprob prob, int row, int ncoefs, const int rowqcol1[],
-                               const int rowqcol2[], const double rowqcoef[]);
+  int(XPRS_CC* XPRSchgqrowcoeff)(XPRSprob prob, int row, int rowqcol1, int rowqcol2,
+                                 double rowqcoef);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSloaddelayedrows)(XPRSprob prob, int nrows, const int rowind[]);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSchgobjn)(XPRSprob prob, int objidx, int ncols, const int colind[],
+                            const double objcoef[]);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSsetobjintcontrol)(XPRSprob prob, int objidx, int control, int value);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSsetobjdblcontrol)(XPRSprob prob, int objidx, int control, double value);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSaddcbcutround)(XPRSprob prob,
+                                  void(XPRS_CC* f_cutround)(XPRSprob cbprob, void* cbdata,
+                                                            int ifxpresscuts, int* p_action),
+                                  void* data, int priority);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSremovecbcutround)(XPRSprob prob,
+                                     void(XPRS_CC* f_cutround)(XPRSprob cbprob, void* cbdata,
+                                                               int ifxpresscuts, int* p_action),
+                                     void* data);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSgetcallbacksolution)(XPRSprob prob, int* p_available, double x[], int first,
+                                        int last);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  int(XPRS_CC* XPRSaddmanagedcuts)(XPRSprob prob, int globalvalid, int ncuts, const char rowtype[],
+                                   const double rhs[], const int start[], const int colind[],
+                                   const double cutcoef[]);
   // NOLINTNEXTLINE(readability-identifier-naming)
   int(XPRS_CC* XPRSsaveas)(XPRSprob prob, const char* filename);
 
@@ -179,16 +220,17 @@ public:
                               const std::string& rowName = "") override;
   bool addWarmStart(const std::vector<VarId>& vars, const std::vector<double>& vals) override;
   void addTimes(int x, int y, int z, const std::string& rowName = "") override;
+  bool defineMultipleObjectives(const MultipleObjectives& mo) override;
 
   int getNCols() override { return static_cast<int>(_nCols); }
   int getNRows() override { return static_cast<int>(_nRows); }
   double getInfBound() override { return XPRS_PLUSINFINITY; }
 
-  MIPxpressWrapper(FactoryOptions& factoryOpt, Options* opt)
-      : _factoryOptions(factoryOpt), _options(opt) {
-    openXpress();
-  };
-  ~MIPxpressWrapper() override { closeXpress(); };
+  // Constructor and destructor are defined out-of-line in MIP_xpress_wrap.cpp because the
+  // unique_ptr callback-payload members need the complete struct types to be
+  // constructed/destroyed (they are only forward-declared here).
+  MIPxpressWrapper(FactoryOptions& factoryOpt, Options* opt);
+  ~MIPxpressWrapper() override;
 
   static std::string getDescription(FactoryOptions& factoryOpt,
                                     MiniZinc::SolverInstanceBase::Options* opt = nullptr);
@@ -228,12 +270,28 @@ private:
   std::vector<int> _indicatorVars;         // Binary variable indices
   std::vector<int> _indicatorComplements;  // Complement flags
 
-  // Bilinear term data (for constraints like z = x*y, implemented via XPRSaddqmatrix):
+  // Bilinear term data (for constraints like z = x*y, implemented via XPRSchgqrowcoeff):
   struct BilinearTerm {
     int row;      // Row index where constraint is added
     int x, y, z;  // Variables: z = x * y
   };
   std::vector<BilinearTerm> _bilinearTerms;
+
+  // Delayed (lazy) row indices - flushed via XPRSloaddelayedrows in loadProblem()
+  std::vector<int> _delayedRowIdx;
+
+  // Multiple-objective definitions - buffered here, flushed in loadProblem() after columns exist
+  struct MultiObjTerm {
+    double weight;  // Objective weight (sign encodes goal direction: -1 min, +1 max)
+    int col;        // Objective variable column index
+    int priority;   // Objective priority (higher solved first)
+  };
+  std::vector<MultiObjTerm> _multiObj;
+
+  // Callback payloads registered with Xpress in solve(); owned here so they remain valid
+  // for the whole solve and are freed when the wrapper is destroyed.
+  std::unique_ptr<UserSolutionCallbackData> _solCbData;
+  std::unique_ptr<UserCutCallbackData> _cutCbData;
 
   size_t _nCols{0};
   size_t _nRows{0};
@@ -246,6 +304,7 @@ private:
   void checkDLL();
 
   void setUserSolutionCallback();
+  void setUserCutCallback();
   void setOptions();
   void writeModelIfRequested();
   void loadProblem();

--- a/share/minizinc/Preferences.json
+++ b/share/minizinc/Preferences.json
@@ -9,6 +9,8 @@
     ["org.minizinc.mip.scip", "-DQuadrFloatSolverConfig=true", ""],
     ["org.minizinc.mip.scip", "-DCumulativeSolverConfig=true", ""],
     ["org.minizinc.mip.scip", "-DOrbisackSolverConfig=true", ""],
-    ["org.minizinc.mip.scip", "-DOrbitopeSolverConfig=true", ""]
+    ["org.minizinc.mip.scip", "-DOrbitopeSolverConfig=true", ""],
+    ["org.minizinc.mip.xpress", "-DQuadrIntSolverConfig=true", ""],
+    ["org.minizinc.mip.xpress", "-DQuadrFloatSolverConfig=true", ""]
   ]
 }

--- a/solvers/MIP/MIP_xpress_wrap.cpp
+++ b/solvers/MIP/MIP_xpress_wrap.cpp
@@ -32,6 +32,14 @@ struct UserSolutionCallbackData {
   std::vector<double>* x;  // Pointer to wrapper's _x vector
 };
 
+// Data passed to the cut-round callback for generating user cuts
+struct UserCutCallbackData {
+  MIPWrapper::CBUserInfo* info;
+  XpressPlugin* plugin;
+  size_t nCols;
+  std::vector<double> x;  // Scratch buffer for the current relaxation solution
+};
+
 // Message callback for solver output
 static void XPRS_CC xpress_message_callback(XPRSprob prob, void* context, const char* msg, int len,
                                             int msgtype) {
@@ -85,6 +93,8 @@ void XpressPlugin::loadDll() {
   load_symbol_dynamic(_inner, XPRSgetlasterror);
   load_symbol_dynamic(_inner, XPRSaddcbintsol);
   load_symbol_dynamic(_inner, XPRSaddcbmessage);
+  load_symbol_dynamic(_inner, XPRSremovecbintsol);
+  load_symbol_dynamic(_inner, XPRSremovecbmessage);
   load_symbol_dynamic(_inner, XPRSgetcontrolinfo);
   load_symbol_dynamic(_inner, XPRSgetintcontrol);
   load_symbol_dynamic(_inner, XPRSgetintcontrol64);
@@ -93,22 +103,28 @@ void XpressPlugin::loadDll() {
   load_symbol_dynamic(_inner, XPRSgetstringcontrol);
   load_symbol_dynamic(_inner, XPRSsetstrcontrol);
 
-  // Optional functions (may not be available in all Xpress versions)
-  try {
-    load_symbol_dynamic(_inner, XPRSaddmipsol);
-  } catch (const MiniZinc::PluginError&) {
-    XPRSaddmipsol = nullptr;  // Function not available, set to nullptr
+  // Optional functions (may not be available in all Xpress versions). Each is set to
+  // nullptr if the running Xpress library does not export it; every call site checks for
+  // null before use. Multi-objective needs all three of chgobjn/setobj{int,dbl}control;
+  // user cuts need all three of addcbcutround/getcallbacksolution/addmanagedcuts.
+#define load_optional_symbol(name)         \
+  try {                                    \
+    load_symbol_dynamic(_inner, name);     \
+  } catch (const MiniZinc::PluginError&) { \
+    (name) = nullptr;                      \
   }
-  try {
-    load_symbol_dynamic(_inner, XPRSaddindicators);
-  } catch (const MiniZinc::PluginError&) {
-    XPRSaddindicators = nullptr;  // Function not available, set to nullptr
-  }
-  try {
-    load_symbol_dynamic(_inner, XPRSaddqmatrix);
-  } catch (const MiniZinc::PluginError&) {
-    XPRSaddqmatrix = nullptr;  // Function not available, set to nullptr
-  }
+  load_optional_symbol(XPRSaddmipsol);
+  load_optional_symbol(XPRSaddindicators);
+  load_optional_symbol(XPRSchgqrowcoeff);
+  load_optional_symbol(XPRSloaddelayedrows);
+  load_optional_symbol(XPRSchgobjn);
+  load_optional_symbol(XPRSsetobjintcontrol);
+  load_optional_symbol(XPRSsetobjdblcontrol);
+  load_optional_symbol(XPRSaddcbcutround);
+  load_optional_symbol(XPRSremovecbcutround);
+  load_optional_symbol(XPRSgetcallbacksolution);
+  load_optional_symbol(XPRSaddmanagedcuts);
+#undef load_optional_symbol
   load_symbol_dynamic(_inner, XPRSsaveas);
 }
 
@@ -149,6 +165,15 @@ void MIPxpressWrapper::closeXpress() {
   _plugin->XPRSfree();
   delete _plugin;
 }
+
+// Constructor and destructor are out-of-line here (not in the header) because the
+// unique_ptr<UserSolutionCallbackData/UserCutCallbackData> members require the complete
+// struct types (defined above in this file) to be constructed/destroyed.
+MIPxpressWrapper::MIPxpressWrapper(FactoryOptions& factoryOpt, Options* opt)
+    : _factoryOptions(factoryOpt), _options(opt) {
+  openXpress();
+}
+MIPxpressWrapper::~MIPxpressWrapper() { closeXpress(); }
 
 void MIPxpressWrapper::checkDLL() {
   if (!_factoryOptions.xpressDll.empty()) {
@@ -249,7 +274,7 @@ string MIPxpressWrapper::getId() { return "xpress"; }
 string MIPxpressWrapper::getName() { return "Xpress"; }
 
 vector<string> MIPxpressWrapper::getTags() {
-  // Quadratic constraints now supported via XPRSaddqmatrix
+  // Quadratic constraints now supported via XPRSchgqrowcoeff
   // Current C API migration supports: LP, MIP, indicator constraints, warm start, quadratic
   return {"mip", "float", "api", "float_times"};
 }
@@ -851,6 +876,89 @@ static void XPRS_CC user_sol_notify_callback(XPRSprob problem, void* userData) {
   }
 }
 
+// Cut-round callback: fired at each node before a round of cutting, to allow the user cut
+// generators to separate valid inequalities against the current LP relaxation. These are
+// "user cuts": they only tighten the relaxation and must never cut off an integer-feasible
+// point. Cuts are handed to Xpress via XPRSaddmanagedcuts (globally valid, optimizer-managed).
+static void XPRS_CC user_cut_round_callback(XPRSprob prob, void* cbdata, int ifxpresscuts,
+                                            int* p_action) {
+  (void)ifxpresscuts;  // unused: we always separate our own cuts when violated
+  auto* data = (UserCutCallbackData*)cbdata;
+  MIPWrapper::CBUserInfo* info = data->info;
+
+  // Default action: continue unchanged (-1). If we add cuts, Xpress reoptimizes and,
+  // because we return a non-negative action, fires the callback again.
+  *p_action = -1;
+
+  if (info->cutcbfn == nullptr || (info->cutMask & MIPWrapper::MaskConsType_Usercut) == 0) {
+    return;
+  }
+
+  // Apply only one round of cuts per node. The
+  // callback fires before a round, so on the first invocation CUTROUNDS is 0.
+  int cutRounds = 0;
+  data->plugin->XPRSgetintattrib(prob, XPRS_CUTROUNDS, &cutRounds);
+  if (cutRounds >= 1) {
+    return;
+  }
+
+  // Fetch the current LP relaxation solution. The solution vector is indexed in the original
+  // (input) column space, so it uses XPRS_INPUTCOLS, not XPRS_COLS.
+  int inputCols = 0;
+  data->plugin->XPRSgetintattrib(prob, XPRS_INPUTCOLS, &inputCols);
+  if (inputCols <= 0) {
+    return;
+  }
+  data->x.resize(inputCols);
+  int available = 0;
+  int rc =
+      data->plugin->XPRSgetcallbacksolution(prob, &available, data->x.data(), 0, inputCols - 1);
+  if (rc != 0 || available == 0) {
+    return;  // No relaxation solution available in this callback context
+  }
+
+  MIPWrapper::Output outpRlx;
+  outpRlx.x = data->x.data();
+  outpRlx.nCols = inputCols;
+
+  // Ask the registered cut generators for cuts against this fractional point.
+  // fMIPSol = false: this is an LP relaxation, not an integer-feasible solution.
+  MIPWrapper::CutInput cutInput;
+  info->cutcbfn(outpRlx, cutInput, info->psi, false);
+
+  for (auto& cd : cutInput) {
+    // Only user cuts are handled here. Lazy cuts require the pre-integer-solution callback
+    // (deferred), so skip any cut that is lazy-only.
+    if ((cd.mask & MIPWrapper::MaskConsType_Usercut) == 0) {
+      continue;
+    }
+    char rowtype;
+    switch (cd.sense) {
+      case MIPWrapper::LQ:
+        rowtype = 'L';
+        break;
+      case MIPWrapper::EQ:
+        rowtype = 'E';
+        break;
+      case MIPWrapper::GQ:
+        rowtype = 'G';
+        break;
+      default:
+        continue;
+    }
+    int cutStart[2] = {0, static_cast<int>(cd.rmatind.size())};
+    // globalvalid = 1: the cut is valid for the whole tree (a user cut cuts off no
+    // integer-feasible point). Coefficients are in original-variable space; Xpress presolves
+    // the cut automatically.
+    rc = data->plugin->XPRSaddmanagedcuts(prob, 1, 1, &rowtype, &cd.rhs, cutStart,
+                                          cd.rmatind.data(), cd.rmatval.data());
+    if (rc != 0) {
+      std::cerr << "  MIPxpressWrapper: failed to add user cut (error code: " << rc << ")"
+                << std::endl;
+    }
+  }
+}
+
 void MIPxpressWrapper::doAddVars(size_t n, double* obj, double* lb, double* ub, VarType* vt,
                                  string* names) {
   if (_problemLoaded) {
@@ -915,7 +1023,18 @@ void MIPxpressWrapper::addRow(int nnz, int* rmatind, double* rmatval, LinConType
     _rowcoef.push_back(rmatval[i]);
   }
 
+  const int rowIndex = static_cast<int>(_nRows);  // index of this row (before increment)
   _nRows++;
+
+  // Xpress delayed rows implement "lazy constraints": Xpress keeps them out of the active
+  // matrix and only reinserts a row when an integer solution violates it. Xpress has no
+  // static "user cut" concept for rows added upfront (user cuts are only meaningful for
+  // dynamically generated cuts via callbacks, which are out of scope here), so only
+  // MaskConsType_Lazy is acted on. The row indices are flushed via XPRSloaddelayedrows in
+  // loadProblem(), after the rows exist in the matrix.
+  if ((mask & MaskConsType_Lazy) != 0) {
+    _delayedRowIdx.push_back(rowIndex);
+  }
 }
 
 void MIPxpressWrapper::writeModelIfRequested() {
@@ -991,22 +1110,66 @@ void MIPxpressWrapper::loadProblem() {
     }
   }
 
-  // Add bilinear terms using XPRSaddqmatrix
+  // Add bilinear terms using XPRSchgqrowcoeff
   if (!_bilinearTerms.empty()) {
-    if (_plugin->XPRSaddqmatrix == nullptr) {
-      throw XpressException("XPRSaddqmatrix not available for bilinear constraints");
+    if (_plugin->XPRSchgqrowcoeff == nullptr) {
+      throw XpressException("XPRSchgqrowcoeff not available for bilinear constraints");
     }
 
-    // Add each bilinear term as a quadratic matrix entry
-    // Note: Q matrix is symmetric, so x*y term needs coefficient 0.5
-    // (contribution is 0.5*Q[x,y]*x*y + 0.5*Q[y,x]*y*x = Q[x,y]*x*y when Q is symmetric)
+    // Xpress stores a symmetric Q matrix per row, so an off-diagonal product x*y (x != y) is
+    // entered once with coefficient 0.5: Xpress fills the symmetric counterpart, giving
+    // 0.5*x*y + 0.5*y*x = x*y. A diagonal square term x*x has no distinct counterpart, so it
+    // must be entered with coefficient 1.0 to yield x*x (using 0.5 would give only 0.5*x*x -
+    // the cause of a previously wrong convex-quadratic result).
+    //
+    // Each product z=x*y occupies its own generated defining row (MiniZinc introduces an
+    // auxiliary variable per product during flattening), so every row carries exactly one
+    // quadratic term. We therefore set that single coefficient directly with
+    // XPRSchgqrowcoeff rather than batching a row's matrix with XPRSaddqmatrix.
     for (const auto& term : _bilinearTerms) {
-      int mqcol1[] = {term.x};
-      int mqcol2[] = {term.y};
-      double dqe[] = {0.5};  // Coefficient 0.5 for symmetric Q matrix
+      rc = _plugin->XPRSchgqrowcoeff(_problem, term.row, term.x, term.y,
+                                     term.x == term.y ? 1.0 : 0.5);
+      check_xpress_return(rc, "Failed to set quadratic coefficient");
+    }
+  }
 
-      rc = _plugin->XPRSaddqmatrix(_problem, term.row, 1, mqcol1, mqcol2, dqe);
-      check_xpress_return(rc, "Failed to add quadratic matrix");
+  // Mark delayed (lazy) rows. Must be done after the rows exist in the matrix
+  // (XPRSaddrows above). Xpress will keep these rows out of the active problem and only
+  // reinsert one when an integer-feasible solution violates it.
+  if (!_delayedRowIdx.empty()) {
+    if (_plugin->XPRSloaddelayedrows == nullptr) {
+      throw XpressException(
+          "Lazy constraints requested but XPRSloaddelayedrows is not available in this version "
+          "of Xpress");
+    }
+    rc = _plugin->XPRSloaddelayedrows(_problem, static_cast<int>(_delayedRowIdx.size()),
+                                      _delayedRowIdx.data());
+    check_xpress_return(rc, "Failed to load delayed (lazy) rows");
+  }
+
+  // Define multiple objectives (buffered by defineMultipleObjectives) now that the columns
+  // exist in the problem. XPRSloadmip above already created objective 0 (an empty/zero
+  // objective), so we OVERWRITE objective 0 with the first goal and create objectives
+  // 1..n-1 for the rest via XPRSchgobjn - this yields exactly n objectives, not n+1.
+  // Priority and weight are set per objective through the XPRS_OBJECTIVE_* controls.
+  if (!_multiObj.empty()) {
+    if (_plugin->XPRSchgobjn == nullptr || _plugin->XPRSsetobjintcontrol == nullptr ||
+        _plugin->XPRSsetobjdblcontrol == nullptr) {
+      throw XpressException(
+          "Multiple objectives requested but the multi-objective functions are not available "
+          "in this version of Xpress");
+    }
+    for (int i = 0; i < static_cast<int>(_multiObj.size()); ++i) {
+      const auto& o = _multiObj[i];
+      int colind[] = {o.col};
+      double objcoef[] = {1.0};
+      // objidx i: i==0 overwrites the objective created by XPRSloadmip; i>0 creates a new one.
+      rc = _plugin->XPRSchgobjn(_problem, i, 1, colind, objcoef);
+      check_xpress_return(rc, "Failed to set objective coefficients");
+      rc = _plugin->XPRSsetobjintcontrol(_problem, i, XPRS_OBJECTIVE_PRIORITY, o.priority);
+      check_xpress_return(rc, "Failed to set objective priority");
+      rc = _plugin->XPRSsetobjdblcontrol(_problem, i, XPRS_OBJECTIVE_WEIGHT, o.weight);
+      check_xpress_return(rc, "Failed to set objective weight");
     }
   }
 
@@ -1017,6 +1180,9 @@ void MIPxpressWrapper::solve() {
   // Set output log level and message callback for solver output
   _plugin->XPRSsetintcontrol(_problem, XPRS_OUTPUTLOG, _options->msgLevel);
   if (_options->msgLevel > 0) {
+    // Clear any previously registered message callback first, so a second solve() on the
+    // same problem does not stack duplicate callbacks (passing nullptr removes all of them).
+    _plugin->XPRSremovecbmessage(_problem, nullptr, nullptr);
     _plugin->XPRSaddcbmessage(_problem, xpress_message_callback, nullptr, 0);
   }
 
@@ -1029,8 +1195,9 @@ void MIPxpressWrapper::solve() {
   // Write model if requested
   writeModelIfRequested();
 
-  // Set callback if needed
+  // Set callbacks if needed
   setUserSolutionCallback();
+  setUserCutCallback();
 
   // Set objective sense
   int obj_rc = _plugin->XPRSchgobjsense(_problem, _objsense);
@@ -1079,9 +1246,42 @@ void MIPxpressWrapper::setUserSolutionCallback() {
     return;
   }
 
-  auto* data = new UserSolutionCallbackData{&cbui, _problem, _plugin, _nCols, &_x};
+  // Owned by _solCbData so it stays alive for the whole solve and is freed with the wrapper.
+  _solCbData.reset(new UserSolutionCallbackData{&cbui, _problem, _plugin, _nCols, &_x});
 
-  _plugin->XPRSaddcbintsol(_problem, user_sol_notify_callback, data, 0);
+  // Clear any previously registered callback of this type first (nullptr removes all), so a
+  // repeated solve() on the same problem does not stack duplicate callbacks.
+  _plugin->XPRSremovecbintsol(_problem, nullptr, nullptr);
+  _plugin->XPRSaddcbintsol(_problem, user_sol_notify_callback, _solCbData.get(), 0);
+}
+
+void MIPxpressWrapper::setUserCutCallback() {
+  // Only register the cut-round callback if a cut generator that produces user cuts is
+  // active. Lazy-only cut generators need the pre-integer-solution callback, so they are
+  // not driven from here.
+  if (cbui.cutcbfn == nullptr || (cbui.cutMask & MaskConsType_Usercut) == 0) {
+    return;
+  }
+
+  if (_plugin->XPRSaddcbcutround == nullptr || _plugin->XPRSaddmanagedcuts == nullptr ||
+      _plugin->XPRSgetcallbacksolution == nullptr) {
+    // Warn and continue rather than throw: user cuts are redundant valid inequalities that
+    // only tighten the relaxation, so omitting them still yields the correct optimum (just
+    // potentially slower). This differs from lazy constraints (loadProblem), which throw
+    // when unavailable because a missing lazy row changes the feasible region and would
+    // silently produce a wrong answer.
+    std::cerr << "  MIPxpressWrapper: user cut callback requested but the required Xpress "
+                 "functions are not available in this version; continuing without user cuts."
+              << std::endl;
+    return;
+  }
+
+  // Owned by _cutCbData so it stays alive for the whole solve and is freed with the wrapper.
+  _cutCbData.reset(new UserCutCallbackData{&cbui, _plugin, _nCols, {}});
+  // Clear any previously registered callback of this type first (nullptr removes all), so a
+  // repeated solve() on the same problem does not stack duplicate callbacks.
+  _plugin->XPRSremovecbcutround(_problem, nullptr, nullptr);
+  _plugin->XPRSaddcbcutround(_problem, user_cut_round_callback, _cutCbData.get(), 0);
 }
 
 void MIPxpressWrapper::setObjSense(int s) {
@@ -1188,17 +1388,18 @@ bool MIPxpressWrapper::addWarmStart(const std::vector<VarId>& vars,
 
 void MIPxpressWrapper::addTimes(int x, int y, int z, const string& rowName) {
   // Bilinear equality constraint: z = x * y
-  // Implemented via XPRSaddqmatrix (adds x*y quadratic term to the row)
+  // Implemented via XPRSchgqrowcoeff (sets the x*y quadratic coefficient on the row)
 
-  if (_plugin->XPRSaddqmatrix == nullptr) {
-    throw XpressException("Bilinear constraints require XPRSaddqmatrix, which is not available.");
+  if (_plugin->XPRSchgqrowcoeff == nullptr) {
+    throw XpressException("Bilinear constraints require XPRSchgqrowcoeff, which is not available.");
   }
 
   if (_problemLoaded) {
     throw XpressException("Cannot add bilinear constraints after problem is loaded.");
   }
 
-  // Add the linear row: -z = 0 (we'll add x*y quadratic term later via XPRSaddqmatrix)
+  // Add the linear row: -z = 0 (we'll set the x*y quadratic coefficient later via
+  // XPRSchgqrowcoeff)
   int colind[] = {z};
   double colval[] = {-1.0};
   addRow(1, colind, colval, EQ, 0.0, MaskConsType_Normal, rowName);
@@ -1210,6 +1411,39 @@ void MIPxpressWrapper::addTimes(int x, int y, int z, const string& rowName) {
   term.y = y;
   term.z = z;
   _bilinearTerms.push_back(term);
+}
+
+bool MIPxpressWrapper::defineMultipleObjectives(const MultipleObjectives& mo) {
+  // Multiple objectives are set via XPRSchgobjn plus the per-objective priority/weight
+  // controls (see loadProblem). If those functions are not available in this version of
+  // Xpress, report no support so MiniZinc can warn.
+  if (_plugin->XPRSchgobjn == nullptr || _plugin->XPRSsetobjintcontrol == nullptr ||
+      _plugin->XPRSsetobjdblcontrol == nullptr) {
+    return false;
+  }
+
+  // Xpress has a single global objective sense; we fix it to maximize and encode each
+  // goal's direction in the sign of its weight below.
+  setObjSense(1);
+
+  // Buffer the objective definitions; they are flushed in loadProblem() once the columns
+  // exist in the Xpress problem (defineMultipleObjectives is called before loadProblem).
+  //
+  // Distinct priorities => Xpress solves the goals lexicographically (this is all MiniZinc's
+  // goal_hierarchy can express). obj.getWeight() is only ever +/-1.0: it is the goal's
+  // MIN/MAX DIRECTION, not a blend coefficient. Because the global sense is maximize, a
+  // min_goal (weight -1) becomes maximize(-x) = minimize(x). Xpress would blend goals that
+  // share a priority using their weights as a weighted sum, but goal_hierarchy provides
+  // neither equal ranks nor fractional weights, so blended mode is not reachable here.
+  _multiObj.clear();
+  const int nObj = static_cast<int>(mo.size());
+  for (int iobj = 0; iobj < nObj; ++iobj) {
+    const auto& obj = mo.getObjectives()[iobj];
+    // Xpress: higher priority is solved first. Earlier goals in the hierarchy get higher
+    // priority, so priority decreases with index.
+    _multiObj.push_back({obj.getWeight(), obj.getVariable(), nObj - iobj});
+  }
+  return true;
 }
 
 namespace MiniZinc {

--- a/tests/spec/unit/general/bilinear.mzn
+++ b/tests/spec/unit/general/bilinear.mzn
@@ -1,0 +1,24 @@
+/***
+!Test
+solvers: [xpress]
+expected: !Result
+  solution: !Solution
+    x: 5.0
+    y: 5.0
+    objective: !Approx 25.000061
+***/
+
+% Xpress bilinear equality test: z = x * y (a quadratic product handled via XPRSaddqmatrix).
+% maximize z with x + y <= 10 => x = y = 5, z = 25. x and y sit at the linear vertex so they
+% are exact; the objective (z) carries small nonlinear-solver noise (~1e-5), so it is checked
+% with !Approx against the solver's returned value rather than the analytic 25.0.
+var 0.0..10.0: x;
+var 0.0..10.0: y;
+var 0.0..100.0: z;
+
+constraint z = x * y;
+constraint x + y <= 10.0;
+
+solve maximize z;
+
+output ["x = ", show(x), ", y = ", show(y), ", z = ", show(z), "\n"];

--- a/tests/spec/unit/general/bin_pack_multiobj.mzn
+++ b/tests/spec/unit/general/bin_pack_multiobj.mzn
@@ -1,6 +1,6 @@
 /***
 !Test
-solvers: [gurobi]
+solvers: [gurobi, xpress]
 expected: !Result
   solution: !Solution
     load: [3, 8, 10]

--- a/tests/spec/unit/general/convex_quadratic.mzn
+++ b/tests/spec/unit/general/convex_quadratic.mzn
@@ -1,0 +1,25 @@
+/***
+!Test
+solvers: [xpress]
+expected: !Result
+  solution: !Solution
+    objective: !Approx 5.656871
+***/
+
+% Xpress convex quadratic constraint test: x^2 + y^2 <= 16 (a circle).
+% maximize x + y => x = y = 2*sqrt(2), analytic optimum 4*sqrt(2) ~= 5.656854. Xpress solves
+% this through the quadratic path (x*x/y*y added via XPRSaddqmatrix) and returns ~5.656871
+% (the nonlinear solve is accurate to ~1e-5, hence !Approx against the solver's value).
+% Regression guard for the diagonal-term coefficient: x*x must use qmatrix coefficient 1.0,
+% not 0.5. With the old 0.5 bug the constraint became x^2+y^2<=32 and the objective was 8.0.
+var 0.0..5.0: x;
+var 0.0..5.0: y;
+
+constraint x*x + y*y <= 16.0;
+constraint x + y <= 10.0;
+
+var float: objective = x + y;
+
+solve maximize objective;
+
+output ["x = ", show(x), ", y = ", show(y), "\n"];

--- a/tests/spec/unit/general/element_user_cut.mzn
+++ b/tests/spec/unit/general/element_user_cut.mzn
@@ -1,0 +1,31 @@
+/***
+!Test
+solvers: [xpress]
+options:
+  -D: "fXBZCuts01=true; fXBZCutGen=true"
+expected: !Result
+  solution: !Solution
+    objective: 140.0
+***/
+
+% User cut test. The -D flags turn element constraints into a MIP_cut generator that the
+% Xpress wrapper drives from its cut-round callback. User cuts only tighten the relaxation,
+% so the optimum is 140.0 with or without them.
+
+include "all_different.mzn";
+
+int: n = 10;
+array [1..n] of var 0.0..100.0: x;
+array [1..5] of var 1..n: idx;
+array [1..5] of var float: z;
+
+constraint forall (i in 1..n) (x[i] <= 7.0 * i);
+constraint forall (k in 1..5) (z[k] = x[idx[k]]);
+constraint all_different(idx);
+constraint sum (i in 1..n) (x[i]) <= 200.0;
+
+var float: total = sum (k in 1..5) (z[k]) - 0.3 * sum (i in 1..n) (x[i]);
+
+solve maximize total;
+
+output ["idx = ", show(idx), ", total = ", show(total), "\n"];

--- a/tests/spec/unit/general/lazy_constraint.mzn
+++ b/tests/spec/unit/general/lazy_constraint.mzn
@@ -1,0 +1,27 @@
+/***
+!Test
+solvers: [xpress]
+expected: !Result
+  solution: !Solution
+    x: 10
+    y: 0
+***/
+
+% Xpress lazy constraint (delayed row) test.
+% The MIP_lazy annotation marks a linear constraint as delayed: Xpress keeps it out of the
+% active matrix (via XPRSloaddelayedrows) and only reinserts it when an integer-feasible
+% solution violates it. The optimum must equal the one obtained with the row enforced
+% normally. Here 3*x + 2*y <= 30 is binding: without it, maximize 3*x + y gives x=10, y=1
+% (obj 31); with it, the best is x=10, y=0 (obj 30).
+
+var 0..10: x;
+var 0..10: y;
+
+constraint x + y <= 13;
+constraint 2*x + y <= 21;
+
+constraint (3*x + 2*y <= 30) :: MIP_lazy;
+
+solve maximize 3*x + y;
+
+output ["x = ", show(x), ", y = ", show(y), "\n"];


### PR DESCRIPTION
Builds on the Xpress C API migration (#993) by adding several MIP features
and enabling quadratic constraints for Xpress.

### Key Changes

**Lazy constraints**
- A constraint annotated `:: lazy_constraint` (`MIP_lazy`) is registered as a delayed
  row via `XPRSloaddelayedrows`, so Xpress only brings it into the active problem when an
  integer-feasible solution violates it.

**Multiple objectives**
- The `goal_hierarchy` annotation now produces a lexicographic multi-objective solve.
  Objective 0 (created by `XPRSloadmip`) is overwritten with the first goal via
  `XPRSchgobjn`, the remaining goals are added as further objectives, and per-objective
  priority/weight are set through the `XPRS_OBJECTIVE_PRIORITY` / `XPRS_OBJECTIVE_WEIGHT`
  controls. This yields exactly one objective per goal.

**User cuts**
- Cut generators that emit `MIP_cut` / `user_cut` inequalities are driven from a cut-round
  callback (`XPRSaddcbcutround`): the wrapper fetches the fractional relaxation with
  `XPRSgetcallbacksolution`, asks the generator to separate, and injects the results as
  optimizer-managed cuts via `XPRSaddmanagedcuts`. Callbacks are de-registered before
  (re-)registration so a repeated solve does not stack duplicates.

**Quadratic / bilinear constraints**
- Enable the `QuadrFloat` / `QuadrInt` solver configurations for Xpress so quadratic and
  bilinear models are handled without extra flags, and fix a quadratic coefficient bug
  (a diagonal square term such as `x*x` was entered with the off-diagonal 0.5 factor,
  leaving constraints like `x*x + y*y <= 16` under-constrained).

### Testing

Added spec tests under `tests/spec/unit/general/`, all with `solvers: [xpress]`:
- `lazy_constraint.mzn` - a lazy row is enforced only when violated (removing the
  annotation changes the optimum, so the delay is actually exercised).
- `element_user_cut.mzn` - a fractional element model where the cut-round callback fires;
  the optimum is unchanged with or without cuts (user cuts only tighten the relaxation).
- `convex_quadratic.mzn` - verifies `x*x + y*y <= 16` is enforced (regression test for the
  coefficient fix above).
- `bilinear.mzn` - `z = x*y`.
- `bin_pack_multiobj.mzn` - added `xpress` to the existing multi-objective test's solver
  list.

All of the above pass against Xpress 9.9.

A changelog entry has been added to `changes.rst`.