### PR TITLE
Fix Dockerfile to include required libs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -133,6 +133,12 @@ jobs:
               --provenance=true --sbom=true --pull --push
           done
 
+      - name: Verify that the image runs
+        shell: bash
+        run: |
+          docker run --pull always --rm \
+            "$IMAGE:${{ steps.rel.outputs.ref }}${{ matrix.suffix }}" --version
+
       # No `| head`: steps run with pipefail, so truncating the output makes the
       # producer die of SIGPIPE and fails the step after a successful push.
       - name: Show what was published

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -11,17 +11,22 @@
 # The build context holds an already-extracted bundle per platform, so nothing is
 # compiled here: <TARGETPLATFORM>/{bin,lib,share}.
 
-ARG DISTROLESS=gcr.io/distroless/cc-debian12:latest
-ARG ALPINE=alpine:3.20
+ARG DISTROLESS=gcr.io/distroless/cc-debian13:latest
+ARG DEBIAN=debian:13-slim
+ARG ALPINE=alpine:latest
 
 FROM scratch AS dist
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/ /opt/minizinc/
 
+FROM ${DEBIAN} AS gnu-source
+RUN apt-get update && apt-get install -y --no-install-recommends zlib1g
+
 FROM ${ALPINE} AS musl-source
-RUN apk add --no-cache libstdc++
+RUN apk add --no-cache libstdc++ zlib
 
 FROM ${DISTROLESS} AS runtime-gnu
+COPY --from=gnu-source /usr/lib/*-linux-gnu/libz.so.1* /opt/minizinc/lib/
 COPY --from=dist /opt/minizinc /opt/minizinc
 # libhighs is dlopened from the bundle's own lib directory.
 ENV PATH=/opt/minizinc/bin:$PATH LD_LIBRARY_PATH=/opt/minizinc/lib
@@ -29,7 +34,7 @@ ENTRYPOINT ["/opt/minizinc/bin/minizinc"]
 
 FROM scratch AS runtime-musl
 COPY --from=musl-source /lib/ld-musl-*.so.1 /lib/
-COPY --from=musl-source /usr/lib/libstdc++.so.6* /usr/lib/libgcc_s.so.1* /usr/lib/
+COPY --from=musl-source /usr/lib/libstdc++.so.6* /usr/lib/libgcc_s.so.1* /usr/lib/libz.so.1 /usr/lib/
 COPY --from=dist /opt/minizinc /opt/minizinc
-ENV PATH=/opt/minizinc/bin:$PATH LD_LIBRARY_PATH=/opt/minizinc/lib
+ENV PATH=/opt/minizinc/bin:$PATH LD_LIBRARY_PATH=/opt/minizinc/lib TMPDIR=/
 ENTRYPOINT ["/opt/minizinc/bin/minizinc"]


### PR DESCRIPTION
### Description

- Fix the Dockerfile runtime images to include zlib.
- Add a simple verification step to the CI to ensure that minizinc executes

### Checklist

* [X] Changes are ready for inclusion in next release
* [X] Changelog has been updated, or no changes required
* [X] Test cases changed or added, or no changes required
* [X] Documentation altered, or no changes required
* [X] Pull request(s) opened for required changes to upstream repos, or none required
