### PR TITLE
Fix element type of concatenated multi-dimensional par arrays

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -56,6 +56,7 @@ Bug fixes:
 -  Fix incorrect index restriction for ``concat_index_6`` function.
 -  Fix output reverse mapping for tuples/record function parameters which shadow
    top-level declarations of the same name.
+-  Fix element type of concatenated multi-dimensional par arrays
 
 .. _v2.10.0:
 

--- a/lib/eval_par.cpp
+++ b/lib/eval_par.cpp
@@ -834,7 +834,19 @@ ArrayLit* eval_array_lit(EnvI& env, Expression* e) {
         auto* ret = bo->type().istuple() ? ArrayLit::constructTuple(Expression::loc(e), v)
                                          : new ArrayLit(Expression::loc(e), v);
         ret->flat(al0->flat() && al1->flat());
-        ret->type(Expression::type(e));
+        Type t = Expression::type(e);
+        if (t.bt() == Type::BT_TOP && t.dim() != 0) {
+          // Operators are not type specialised, so inside the body of a polymorphic '++'
+          // overload the static type of this expression is still the uninstantiated
+          // `array[int] of var opt top`. Recover the element type from the operands, which
+          // have already been evaluated to concrete values.
+          Type et =
+              Type::commonType(env, al0->type().elemType(env), al1->type().elemType(env), false);
+          if (!et.isunknown()) {
+            t = Type::arrType(env, t, et);
+          }
+        }
+        ret->type(t);
         return ret;
       }
       throw EvalError(env, Expression::loc(e), "not an array expression", bo->opToString());

--- a/tests/spec/unit/regression/multidim_concat_elem_type.mzn
+++ b/tests/spec/unit/regression/multidim_concat_elem_type.mzn
@@ -1,0 +1,16 @@
+/***
+!Test
+solvers: [gecode]
+expected: !Error
+  regex: .*array access out of bounds, dimension 2 of array `b' has index set 1\.\.2, but given index is 0.*
+***/
+
+% The body of the multi-dimensional '++' overload is not type specialised, so the
+% concatenation used to evaluate to an array typed `var opt top', which then made
+% reporting an out of bounds access on `b' fail with an internal error.
+array [1..2, 1..2] of int: a = array2d(1..2, 1..2, [1, 2, 3, 4]);
+array [1..2, 1..2, 1..2] of int: b = array3d(1..2, 1..2, 1..2, a ++ a);
+array [int] of int: y = [b[i, j, k] | i in 1..2, j in 0..2, k in 1..2];
+var int: z;
+constraint z = y[1];
+solve satisfy;


### PR DESCRIPTION
Operators are not type specialised, so the '++' inside the polymorphic multidimensional '++' overload evaluated to an array typed `var opt top'. arrayNd then propagated that type into the declared array, and reporting out-of-bounds access to it failed with an internal error.