### PR TITLE
Fix crash in Gecode presolver on set_in over an integer variable

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -57,6 +57,11 @@ Bug fixes:
 -  Fix output reverse mapping for tuples/record function parameters which shadow
    top-level declarations of the same name.
 -  Fix element type of concatenated multi-dimensional par arrays
+-  Fix a crash in the Gecode presolver (``-O3`` and higher) when the flattened
+   model contains a ``set_in`` constraint on an integer variable. The argument
+   was tested for being a variable rather than for being a Boolean variable, so
+   the integer variable was looked up in the space's Boolean variable array
+   (:bugref:`1027`).
 
 .. _v2.10.0:
 

--- a/solvers/gecode/gecode_constraints.cpp
+++ b/solvers/gecode/gecode_constraints.cpp
@@ -1821,21 +1821,7 @@ void p_set_card(SolverInstanceBase& s, const Call* ce) {
 void p_set_in(SolverInstanceBase& s, const Call* ce) {
   auto& gi = static_cast<GecodeSolverInstance&>(s);
   if (!Expression::type(ce->arg(1)).isvar()) {
-    IntSet d = gi.arg2intset(s.env().envi(), ce->arg(1));
-    if (Expression::type(ce->arg(0)).isvar()) {
-      Gecode::IntSetRanges dr(d);
-      Iter::Ranges::Singleton sr(0, 1);
-      Iter::Ranges::Inter<Gecode::IntSetRanges, Iter::Ranges::Singleton> i(dr, sr);
-      IntSet d01(i);
-      if (d01.size() == 0) {
-        gi.currentSpace->fail();
-      } else {
-        rel(*gi.currentSpace, gi.arg2boolvar(ce->arg(0)), IRT_GQ, d01.min());
-        rel(*gi.currentSpace, gi.arg2boolvar(ce->arg(0)), IRT_LQ, d01.max());
-      }
-    } else {
-      dom(*gi.currentSpace, gi.arg2intvar(ce->arg(0)), d);
-    }
+    p_int_in(s, ce);
   } else {
     if (!Expression::type(ce->arg(0)).isvar()) {
       dom(*gi.currentSpace, gi.arg2setvar(ce->arg(1)), SRT_SUP,

--- a/tests/spec/unit/general/set_in_int_var_presolve.mzn
+++ b/tests/spec/unit/general/set_in_int_var_presolve.mzn
@@ -1,0 +1,22 @@
+/***
+!Test
+solvers: [gecode]
+options:
+  -O3: true
+  --only-range-domains: true
+  all_solutions: true
+expected: !Result
+  status: ALL_SOLUTIONS
+  solution: !SolutionSet
+  - !Solution
+    x: 1
+  - !Solution
+    x: 5
+***/
+
+% Test for GitHub issue #1027, where the Gecode presolver posted a set_in
+% constraint on an integer variable as if it were a Boolean variable.
+var int: x;
+constraint x in {1, 3, 5};
+constraint x != 3;
+solve satisfy;


### PR DESCRIPTION
### Description

p_set_in tested its first argument for being a variable rather than a
Boolean variable, so an integer variable was looked up in the space's
Boolean variable array. Delegate the par-set case to p_int_in, which
already implements the same logic correctly.

Fixes #1027

### Checklist

* [x] Changes are ready for inclusion in next release
* [x] Changelog has been updated, or no changes required
* [x] Test cases changed or added, or no changes required
* [x] Documentation altered, or no changes required
* [x] Pull request(s) opened for required changes to upstream repos, or none required
