### PR TITLE
Fix clearing of internal annotations from flatzinc arrays

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -74,6 +74,7 @@ Bug fixes:
 -  Fix `in` on records/tuples whose members are all fixed (:bugref:`1027`).
 -  Fix possible crashes while handling stack overflows on Windows which
    previously would have prevented the stack trace from being printed.
+-  Fix clearing of internal annotations from array declarations in FlatZinc.
 
 .. _v2.10.0:
 

--- a/lib/flatten.cpp
+++ b/lib/flatten.cpp
@@ -5595,6 +5595,10 @@ std::vector<Expression*> cleanup_vardecl(EnvI& env, VarDeclI* vdi, VarDecl* vd,
         Expression::isa<SetLit>(vd->ti()->ranges()[0]->domain())) {
       IntSetVal* isv = Expression::cast<SetLit>(vd->ti()->ranges()[0]->domain())->isv();
       if ((isv != nullptr) && (isv->empty() || isv->min(0) == 1)) {
+        for (auto* ann : env.constants.internalAnn()) {
+          Expression::ann(vd).remove(ann);
+        }
+        Expression::ann(vd).removeCall(env.constants.ann.mzn_check_enum_var);
         return added_constraints;
       }
     }

--- a/tests/spec/unit/regression/checker_array_annotations.fzn
+++ b/tests/spec/unit/regression/checker_array_annotations.fzn
@@ -1,0 +1,4 @@
+var 0..1: X_INTRODUCED_18_;
+var 0..1: X_INTRODUCED_19_;
+array [1..2] of var int: x:: output_array([1..2]) = [X_INTRODUCED_18_,X_INTRODUCED_19_];
+solve satisfy;

--- a/tests/spec/unit/regression/checker_array_annotations.mzc.mzn
+++ b/tests/spec/unit/regression/checker_array_annotations.mzc.mzn
@@ -1,0 +1,4 @@
+enum E;
+array [E] of int: x;
+
+output ["OK"];

--- a/tests/spec/unit/regression/checker_array_annotations.mzn
+++ b/tests/spec/unit/regression/checker_array_annotations.mzn
@@ -1,0 +1,14 @@
+/***
+!Test
+type: compile
+solvers: [gecode]
+extra_files: [checker_array_annotations.mzc.mzn]
+expected: !FlatZinc checker_array_annotations.fzn
+***/
+
+% A checker-required, enum-indexed array becomes a 1-indexed FlatZinc array.
+% Its checker annotations must not be emitted in the FlatZinc model.
+enum E = {A, B};
+array [E] of var 0..1: x;
+
+solve satisfy;


### PR DESCRIPTION
### Description

- Ensures that mzn_check_var etc don't remain in flatzinc

### Checklist

* [X] Changes are ready for inclusion in next release
* [X] Changelog has been updated, or no changes required
* [X] Test cases changed or added, or no changes required
* [X] Documentation altered, or no changes required
* [X] Pull request(s) opened for required changes to upstream repos, or none required
