### PR TITLE
Store flattening paths as an interned tree

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -30,6 +30,15 @@ Changes:
    and user cuts, and enable quadratic and bilinear constraints.
 -  Make built-in Gecode solver interface handle restart annotations and statistics
    output.
+-  Greatly reduce the memory used by two-pass compilation (``--two-pass``,
+   ``-O2`` and above). The paths that identify variables between passes were
+   stored as one string per variable, each spelling out the file name of every
+   frame on the flattening call stack, and held several times over. They are now
+   an interned tree of shared frames, and the text is only built when
+   ``--keep-paths`` or ``--output-paths`` asks for it. Where an expression has
+   picked up more than one path, the deepest one is now kept. Previously the
+   textually longest was kept, which could prefer a shallower path that happened
+   to run through longer file or function names (:bugref:`1029`).
 
 Bug fixes:
 ^^^^^^^^^^

--- a/include/minizinc/flatten_internal.hh
+++ b/include/minizinc/flatten_internal.hh
@@ -23,7 +23,9 @@
 #include <atomic>
 #include <cassert>
 #include <cmath>
+#include <memory>
 #include <random>
+#include <unordered_set>
 #include <utility>
 
 // TODO: Should this be a command line option? It doesn't seem too expensive
@@ -51,6 +53,76 @@ struct MultiPassInfo {
   MultiPassInfo();
 };
 
+/// Interned store for the paths identifying variables across compilation passes.
+///
+/// A path is the flattening call stack, one frame per entry. Written out per
+/// variable that is kilobytes, since every frame repeats its file name; stored
+/// as a tree of shared cons cells it is one pointer. Text is built on demand.
+class PathStore {
+public:
+  struct Node;
+  /// A path, or nullptr for the empty one. Owned by, and only comparable within,
+  /// the store that handed it out, hence the deleted copy below.
+  using Path = const Node*;
+  struct Node {
+    Path parent;
+    /// Rendered frame text, interned. Null when the frame stands in for `spliced`.
+    const std::string* frame;
+    /// An earlier path spliced in here, for compilation resumed away from where
+    /// the expression came from.
+    Path spliced;
+  };
+
+  PathStore() = default;
+  PathStore(const PathStore&) = delete;
+  PathStore& operator=(const PathStore&) = delete;
+
+  /// Return \a parent extended by a frame rendering as \a frame.
+  Path extend(Path parent, const std::string& frame);
+  /// Return \a parent extended by a frame splicing in \a spliced.
+  Path extendSpliced(Path parent, Path spliced);
+  /// Write the text of \a p.
+  static void print(std::ostream& os, Path p);
+  /// Text of \a p.
+  static std::string toString(Path p);
+  /// Leftmost frame of \a p, which by construction reads "<filename>|<line>|...",
+  /// or nullptr if \a p is empty.
+  static const std::string* leadingFrame(Path p);
+  /// Number of frames in \a p, spliced ones included. Walks the path; only used
+  /// to pick between the few paths one expression accumulated.
+  static unsigned int depth(Path p);
+  /// Index identifying \a p, for an annotation to carry instead of its text.
+  unsigned int markerIndex(Path p);
+  /// The path index \a i identifies, or nullptr if it identifies none.
+  Path fromMarkerIndex(IntVal i) const;
+
+private:
+  struct NodeHash {
+    size_t operator()(const Node& n) const {
+      // Cells are aligned, so a pointer's low bits carry nothing: mix, do not shift.
+      size_t h = 0;
+      for (const void* p : {static_cast<const void*>(n.parent), static_cast<const void*>(n.frame),
+                            static_cast<const void*>(n.spliced)}) {
+        h ^= std::hash<const void*>()(p) + 0x9e3779b9 + (h << 6) + (h >> 2);
+      }
+      return h;
+    }
+  };
+  struct NodeEq {
+    bool operator()(const Node& a, const Node& b) const {
+      return a.parent == b.parent && a.frame == b.frame && a.spliced == b.spliced;
+    }
+  };
+  /// Frame texts, interned. Node-based, so the addresses stay put.
+  std::unordered_set<std::string> _frames;
+  /// Paths that have been handed a marker index, and the index of each.
+  std::vector<Path> _markerPaths;
+  std::unordered_map<Path, unsigned int> _markers;
+  /// Cons cells, interned so equal paths are the same pointer. The element is
+  /// the whole key, so equality cannot miss a field.
+  std::unordered_set<Node, NodeHash, NodeEq> _nodes;
+};
+
 struct VarPathStore {
   // Used for disabling path construction past the maxPathDepth of previous passes
   unsigned int maxPathDepth;
@@ -59,19 +131,23 @@ struct VarPathStore {
     KeepAlive decl;
     unsigned int passNumber;
   };
-  // Store mapping from path string to (VarDecl, pass_no) tuples
-  typedef std::unordered_map<std::string, PathVar> PathMap;
+  // Store mapping from path to (VarDecl, pass_no) tuples
+  using PathMap = std::unordered_map<PathStore::Path, PathVar>;
   // Mapping from arbitrary Expressions to paths
-  typedef KeepAliveMap<std::string> ReversePathMap;
+  using ReversePathMap = KeepAliveMap<PathStore::Path>;
 
   PathMap pathMap;
   ReversePathMap reversePathMap;
   ASTStringSet filenameSet;
+  /// Shared with the other passes' environments: paths compare by pointer, so
+  /// every pass must intern into the same store.
+  std::shared_ptr<PathStore> paths;
 
   VarPathStore();
   PathMap& getPathMap() { return pathMap; }
   ReversePathMap& getReversePathMap() { return reversePathMap; }
   ASTStringSet& getFilenameSet() { return filenameSet; }
+  PathStore& getPaths() { return *paths; }
 };
 
 class ErrStreamWrapper {
@@ -348,9 +424,16 @@ public:
     Ctx ctx;
     bool tag;
     bool replaced;
-    CallStackEntry() : e(nullptr), tag(false), replaced(false) {}
+    /// Path up to this entry, filled on first request rather than at push time:
+    /// a comprehension iterator is assigned its value after being pushed.
+    PathStore::Path path;
+    /// An earlier path this entry stands for, set where compilation resumes away
+    /// from where the expression came from. Contributed instead of `e`'s frame.
+    PathStore::Path pathSplice;
+    CallStackEntry()
+        : e(nullptr), tag(false), replaced(false), path(nullptr), pathSplice(nullptr) {}
     CallStackEntry(Expression* e0, bool tag0, const Ctx& ctx0)
-        : e(e0), ctx(ctx0), tag(tag0), replaced(false) {}
+        : e(e0), ctx(ctx0), tag(tag0), replaced(false), path(nullptr), pathSplice(nullptr) {}
   };
   std::vector<CallStackEntry> callStack;
   std::vector<int> idStack;
@@ -564,6 +647,11 @@ public:
   ASTString reifyId(const ASTString& id);
   static ASTString halfReifyId(const ASTString& id);
   bool dumpPath(std::ostream& os, bool force = false);
+  /// Path of the current call stack, or nullptr if untracked at this depth.
+  PathStore::Path currentPath(bool force = false);
+  /// Have the innermost call-stack entry contribute \a p to the path instead of
+  /// its own frame, so what is flattened under it continues from there.
+  void setPathSplice(PathStore::Path p) { callStack.back().pathSplice = p; }
   int addWarning(const std::string& msg);
   int addWarning(const Location& loc, const std::string& msg, bool dumpStack = true);
   void collectVarDecls(bool b);

--- a/include/minizinc/flatten_internal.hh
+++ b/include/minizinc/flatten_internal.hh
@@ -657,6 +657,8 @@ public:
   void collectVarDecls(bool b);
 
   void copyPathMapsAndState(EnvI& env);
+  /// Drop state no later pass reads, so the GC can reclaim it while they run.
+  void releasePassState();
   /// deprecated, use Solns2Out
   std::ostream& evalOutput(std::ostream& os, std::ostream& log);
   Call* surroundingCall() const;

--- a/include/minizinc/hash.hh
+++ b/include/minizinc/hash.hh
@@ -299,6 +299,9 @@ public:
   /// Remove binding of \a e from map
   void remove(Expression* e) { _m.erase(e); }
   void clear() { _m.clear(); }
+  /// Take over \a other's contents. Only the map moves: both objects stay
+  /// registered with the collector where they are.
+  void swap(KeepAliveMap& other) { _m.swap(other._m); }
   template <class D>
   void dump() {
     for (auto i = _m.begin(); i != _m.end(); ++i) {

--- a/lib/flatten.cpp
+++ b/lib/flatten.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <map>
 #include <sstream>
 #include <unordered_map>
@@ -516,16 +517,6 @@ bool update_bounds(EnvI& envi, VarDecl* ovd, VarDecl* vd) {
   return tighter;
 }
 
-std::string get_path(EnvI& env) {
-  std::string path;
-  std::stringstream ss;
-  if (env.dumpPath(ss)) {
-    path = ss.str();
-  }
-
-  return path;
-}
-
 inline Location get_loc(EnvI& env, Expression* e1, Expression* e2) {
   if (e1 != nullptr) {
     return Expression::loc(e1).introduce();
@@ -539,32 +530,27 @@ inline Id* get_id(EnvI& env, Id* origId) {
   return origId != nullptr ? origId : new Id(Location().introduce(), env.genId(), nullptr);
 }
 
-StringLit* get_longest_mzn_path_annotation(EnvI& env, const Expression* e) {
-  StringLit* sl = nullptr;
-
+/// Path recorded for \a e while flattening, or nullptr. Where an expression
+/// picked up several, the deepest wins.
+PathStore::Path get_recorded_path(EnvI& env, const Expression* e) {
   if (const auto* vd = Expression::dynamicCast<const VarDecl>(e)) {
     VarPathStore::ReversePathMap& reversePathMap = env.varPathStore.getReversePathMap();
     auto it = reversePathMap.find(vd->id()->decl());
-    if (it != reversePathMap.end()) {
-      sl = new StringLit(Location(), it->second);
-    }
-  } else {
-    for (ExpressionSetIter it = Expression::ann(e).begin(); it != Expression::ann(e).end(); ++it) {
-      if (Call* ca = Expression::dynamicCast<Call>(*it)) {
-        if (ca->id() == env.constants.ann.mzn_path) {
-          auto* sl1 = Expression::cast<StringLit>(ca->arg(0));
-          if (sl != nullptr) {
-            if (sl1->v().size() > sl->v().size()) {
-              sl = sl1;
-            }
-          } else {
-            sl = sl1;
-          }
+    return it != reversePathMap.end() ? it->second : nullptr;
+  }
+  PathStore::Path best = nullptr;
+  for (ExpressionSetIter it = Expression::ann(e).begin(); it != Expression::ann(e).end(); ++it) {
+    if (Call* ca = Expression::dynamicCast<Call>(*it)) {
+      if (ca->id() == env.constants.ann.mzn_path && Expression::isa<IntLit>(ca->arg(0))) {
+        PathStore::Path p = env.varPathStore.getPaths().fromMarkerIndex(
+            IntLit::v(Expression::cast<IntLit>(ca->arg(0))));
+        if (p != nullptr && (best == nullptr || PathStore::depth(p) > PathStore::depth(best))) {
+          best = p;
         }
       }
     }
   }
-  return sl;
+  return best;
 }
 
 void add_path_annotation(EnvI& env, Expression* e) {
@@ -577,21 +563,24 @@ void add_path_annotation(EnvI& env, Expression* e) {
 
     VarPathStore::ReversePathMap& reversePathMap = env.varPathStore.getReversePathMap();
 
-    std::vector<Expression*> path_args(1);
-    std::string p;
     auto it = reversePathMap.find(e);
-    if (it == reversePathMap.end()) {
-      p = get_path(env);
-    } else {
-      p = it->second;
+    PathStore::Path p = it == reversePathMap.end() ? env.currentPath() : it->second;
+    if (p == nullptr) {
+      return;
+    }
+    // A variable's path is recovered from the reverse path map, never from an
+    // annotation, so only build one if it is going to be printed.
+    if (Expression::isa<VarDecl>(e) && !env.fopts.collectMznPaths) {
+      return;
     }
 
-    if (!p.empty()) {
-      path_args[0] = new StringLit(Location(), p);
-      Call* path_call = Call::a(Expression::loc(e), env.constants.ann.mzn_path, path_args);
-      Expression::type(path_call, Type::ann());
-      Expression::addAnnotation(e, path_call);
-    }
+    // A token, not the text: rewriting a constraint later must recover its path
+    // whether or not paths were asked for. The text is filled in before printing.
+    std::vector<Expression*> path_args(1);
+    path_args[0] = IntLit::a(env.varPathStore.getPaths().markerIndex(p));
+    Call* path_call = Call::a(Expression::loc(e), env.constants.ann.mzn_path, path_args);
+    Expression::type(path_call, Type::ann());
+    Expression::addAnnotation(e, path_call);
   }
 }
 
@@ -657,8 +646,8 @@ VarDecl* new_vardecl(EnvI& env, const Ctx& ctx, TypeInst* ti, Id* origId, VarDec
 
   // Don't use paths for arrays, structs, or annotations
   if (ti->type().dim() == 0 && !ti->type().structBT() && !ti->type().isAnn()) {
-    std::string path = get_path(env);
-    if (!path.empty()) {
+    PathStore::Path path = env.currentPath();
+    if (path != nullptr) {
       VarPathStore::ReversePathMap& reversePathMap = env.varPathStore.getReversePathMap();
       VarPathStore::PathMap& pathMap = env.varPathStore.getPathMap();
       auto it = pathMap.find(path);
@@ -686,7 +675,7 @@ VarDecl* new_vardecl(EnvI& env, const Ctx& ctx, TypeInst* ti, Id* origId, VarDec
             // We may not have seen the pointed to decl just yet
             auto path2It = reversePathMap.find(ovd->id()->decl());
             if (path2It != reversePathMap.end()) {
-              std::string path2 = path2It->second;
+              PathStore::Path path2 = path2It->second;
               VarPathStore::PathVar vd_tup{vd, env.multiPassInfo.currentPassNumber};
 
               pathMap[path] = vd_tup;
@@ -758,7 +747,70 @@ VarDecl* new_vardecl(EnvI& env, const Ctx& ctx, TypeInst* ti, Id* origId, VarDec
 
 MultiPassInfo::MultiPassInfo() : currentPassNumber(0), finalPassNumber(1) {}
 
-VarPathStore::VarPathStore() : maxPathDepth(0) {}
+VarPathStore::VarPathStore() : maxPathDepth(0), paths(std::make_shared<PathStore>()) {}
+
+PathStore::Path PathStore::extend(Path parent, const std::string& frame) {
+  return &*_nodes.insert({parent, &*_frames.insert(frame).first, nullptr}).first;
+}
+
+PathStore::Path PathStore::extendSpliced(Path parent, Path spliced) {
+  return &*_nodes.insert({parent, nullptr, spliced}).first;
+}
+
+unsigned int PathStore::depth(Path p) {
+  unsigned int d = 0;
+  for (; p != nullptr; p = p->parent) {
+    d += p->frame != nullptr ? 1 : depth(p->spliced);
+  }
+  return d;
+}
+
+void PathStore::print(std::ostream& os, Path p) {
+  if (p == nullptr) {
+    return;
+  }
+  // Cells point at their parent, so recurse to the root and write on the way back.
+  print(os, p->parent);
+  if (p->frame != nullptr) {
+    os << *p->frame;
+  } else {
+    print(os, p->spliced);
+  }
+  os << ";";
+}
+
+std::string PathStore::toString(Path p) {
+  std::ostringstream oss;
+  print(oss, p);
+  return oss.str();
+}
+
+unsigned int PathStore::markerIndex(Path p) {
+  auto it = _markers.find(p);
+  if (it == _markers.end()) {
+    _markerPaths.push_back(p);
+    it = _markers.emplace(p, static_cast<unsigned int>(_markerPaths.size() - 1)).first;
+  }
+  return it->second;
+}
+
+PathStore::Path PathStore::fromMarkerIndex(IntVal i) const {
+  if (!i.isFinite() || i < 0) {
+    return nullptr;
+  }
+  auto idx = static_cast<size_t>(i.toInt());
+  return idx < _markerPaths.size() ? _markerPaths[idx] : nullptr;
+}
+
+const std::string* PathStore::leadingFrame(Path p) {
+  if (p == nullptr) {
+    return nullptr;
+  }
+  while (p->parent != nullptr) {
+    p = p->parent;
+  }
+  return p->frame != nullptr ? p->frame : leadingFrame(p->spliced);
+}
 
 void OutputSectionStore::add(EnvI& env, ASTString section, Expression* e, bool json) {
   if (json) {
@@ -1178,8 +1230,14 @@ void EnvI::copyPathMapsAndState(EnvI& env) {
   multiPassInfo.finalPassNumber = env.multiPassInfo.finalPassNumber;
   multiPassInfo.currentPassNumber = env.multiPassInfo.currentPassNumber;
 
-  varPathStore.pathMap = env.varPathStore.getPathMap();
-  varPathStore.reversePathMap = env.varPathStore.getReversePathMap();
+  // Share, do not copy: paths compare by pointer, so this pass must intern into
+  // the same store as the last.
+  varPathStore.paths = env.varPathStore.paths;
+  // Take the maps rather than copy them: releasePassState leaves nothing behind
+  // that reads them, and on a large model they run to millions of entries, each
+  // holding a KeepAlive that is also an entry in the collector's root list.
+  varPathStore.pathMap = std::move(env.varPathStore.pathMap);
+  varPathStore.reversePathMap.swap(env.varPathStore.reversePathMap);
 
   varPathStore.filenameSet = env.varPathStore.filenameSet;
   varPathStore.maxPathDepth = env.varPathStore.maxPathDepth;
@@ -2027,117 +2085,140 @@ std::ostream& Env::evalOutput(std::ostream& os, std::ostream& log) {
 EnvI& Env::envi() { return *_e; }
 const EnvI& Env::envi() const { return *_e; }
 
-bool EnvI::dumpPath(std::ostream& os, bool force) {
+PathStore::Path EnvI::currentPath(bool force) {
   force = force ? force : fopts.collectMznPaths;
   if (callStack.size() > varPathStore.maxPathDepth) {
     if (!force && multiPassInfo.currentPassNumber >= multiPassInfo.finalPassNumber - 1) {
-      return false;
+      return nullptr;
     }
-    varPathStore.maxPathDepth = static_cast<int>(callStack.size());
+    varPathStore.maxPathDepth = static_cast<unsigned int>(callStack.size());
   }
 
-  auto lastError = static_cast<unsigned int>(callStack.size());
+  PathStore& paths = varPathStore.getPaths();
+  PathStore::Path path = nullptr;
+  std::ostringstream frame;
+  for (auto& entry : callStack) {
+    // Frames below the top were rendered earlier and cannot have changed: a
+    // frame's contents are fixed for as long as its entry is on the stack.
+    if (entry.path != nullptr) {
+      path = entry.path;
+      continue;
+    }
 
-  std::string major_sep = ";";
-  std::string minor_sep = "|";
-  for (unsigned int i = 0; i < lastError; i++) {
-    Expression* e = callStack[i].e;
-    bool isCompIter = callStack[i].tag;
+    Expression* e = entry.e;
+    bool isCompIter = entry.tag;
     Location loc = Expression::loc(e);
     auto findFilename = varPathStore.filenameSet.find(loc.filename());
     if (findFilename == varPathStore.filenameSet.end()) {
       if (!force && multiPassInfo.currentPassNumber >= multiPassInfo.finalPassNumber - 1) {
-        return false;
+        return nullptr;
       }
       varPathStore.filenameSet.insert(loc.filename());
     }
 
-    // If this call is not a dummy StringLit with empty Location (so that deferred compilation
-    // doesn't drop the paths)
-    if (Expression::eid(e) != Expression::E_STRINGLIT || (loc.firstLine() != 0U) ||
-        (loc.firstColumn() != 0U) || (loc.lastLine() != 0U) || (loc.lastColumn() != 0U)) {
-      os << loc.filename() << minor_sep << loc.firstLine() << minor_sep << loc.firstColumn()
-         << minor_sep << loc.lastLine() << minor_sep << loc.lastColumn() << minor_sep;
-      switch (Expression::eid(e)) {
-        case Expression::E_INTLIT:
-          os << "il" << minor_sep << *e;
-          break;
-        case Expression::E_FLOATLIT:
-          os << "fl" << minor_sep << *e;
-          break;
-        case Expression::E_SETLIT:
-          os << "sl" << minor_sep << *e;
-          break;
-        case Expression::E_BOOLLIT:
-          os << "bl" << minor_sep << *e;
-          break;
-        case Expression::E_STRINGLIT:
-          os << "stl" << minor_sep << *e;
-          break;
-        case Expression::E_ID:
-          if (isCompIter) {
-            // if (e->cast<Id>()->decl()->e()->type().isPar())
-            os << *e << "=" << *Expression::cast<Id>(e)->decl()->e();
-            // else
-            //  os << *e << "=?";
-          } else {
-            os << "id" << minor_sep << *e;
-          }
-          break;
-        case Expression::E_ANON:
-          os << "anon";
-          break;
-        case Expression::E_ARRAYLIT:
-          os << "al";
-          break;
-        case Expression::E_ARRAYACCESS:
-          os << "aa";
-          break;
-        case Expression::E_COMP: {
-          const Comprehension* cmp = Expression::cast<Comprehension>(e);
-          if (cmp->set()) {
-            os << "sc";
-          } else {
-            os << "ac";
-          }
-        } break;
-        case Expression::E_ITE:
-          os << "ite";
-          break;
-        case Expression::E_BINOP:
-          os << "bin" << minor_sep << Expression::cast<BinOp>(e)->opToString();
-          break;
-        case Expression::E_UNOP:
-          os << "un" << minor_sep << Expression::cast<UnOp>(e)->opToString();
-          break;
-        case Expression::E_CALL:
-          if (fopts.onlyToplevelPaths) {
-            return false;
-          }
-          os << "ca" << minor_sep << Expression::cast<Call>(e)->id();
-          break;
-        case Expression::E_VARDECL:
-          os << "vd";
-          break;
-        case Expression::E_LET:
-          os << "l";
-          break;
-        case Expression::E_TI:
-          os << "ti";
-          break;
-        case Expression::E_TIID:
-          os << "ty";
-          break;
-        default:
-          assert(false);
-          os << "unknown expression (internal error)";
-          break;
-      }
-      os << major_sep;
-    } else {
-      os << Expression::cast<StringLit>(e)->v() << major_sep;
+    // An entry standing in for an earlier path contributes that, not its own
+    // frame, so deferring an expression does not lose where it came from.
+    if (entry.pathSplice != nullptr) {
+      path = paths.extendSpliced(path, entry.pathSplice);
+      entry.path = path;
+      continue;
     }
+
+    // A StringLit with an empty Location is a frame pushed by hand; its text is
+    // the frame.
+    if (Expression::eid(e) == Expression::E_STRINGLIT && loc.firstLine() == 0U &&
+        loc.firstColumn() == 0U && loc.lastLine() == 0U && loc.lastColumn() == 0U) {
+      ASTString text = Expression::cast<StringLit>(e)->v();
+      path = paths.extend(path, std::string(text.c_str(), text.size()));
+      entry.path = path;
+      continue;
+    }
+
+    frame.str(std::string());
+    frame.clear();
+    frame << loc.filename() << "|" << loc.firstLine() << "|" << loc.firstColumn() << "|"
+          << loc.lastLine() << "|" << loc.lastColumn() << "|";
+    switch (Expression::eid(e)) {
+      case Expression::E_INTLIT:
+        frame << "il|" << *e;
+        break;
+      case Expression::E_FLOATLIT:
+        frame << "fl|" << *e;
+        break;
+      case Expression::E_SETLIT:
+        frame << "sl|" << *e;
+        break;
+      case Expression::E_BOOLLIT:
+        frame << "bl|" << *e;
+        break;
+      case Expression::E_STRINGLIT:
+        frame << "stl|" << *e;
+        break;
+      case Expression::E_ID:
+        if (isCompIter) {
+          // The value is what tells one iteration's variables from the next's,
+          // so capture it now: the comprehension will have moved on.
+          frame << *e << "=" << *Expression::cast<Id>(e)->decl()->e();
+        } else {
+          frame << "id|" << *e;
+        }
+        break;
+      case Expression::E_ANON:
+        frame << "anon";
+        break;
+      case Expression::E_ARRAYLIT:
+        frame << "al";
+        break;
+      case Expression::E_ARRAYACCESS:
+        frame << "aa";
+        break;
+      case Expression::E_COMP:
+        frame << (Expression::cast<Comprehension>(e)->set() ? "sc" : "ac");
+        break;
+      case Expression::E_ITE:
+        frame << "ite";
+        break;
+      case Expression::E_BINOP:
+        frame << "bin|" << Expression::cast<BinOp>(e)->opToString();
+        break;
+      case Expression::E_UNOP:
+        frame << "un|" << Expression::cast<UnOp>(e)->opToString();
+        break;
+      case Expression::E_CALL:
+        if (fopts.onlyToplevelPaths) {
+          return nullptr;
+        }
+        frame << "ca|" << Expression::cast<Call>(e)->id();
+        break;
+      case Expression::E_VARDECL:
+        frame << "vd";
+        break;
+      case Expression::E_LET:
+        frame << "l";
+        break;
+      case Expression::E_TI:
+        frame << "ti";
+        break;
+      case Expression::E_TIID:
+        frame << "ty";
+        break;
+      default:
+        assert(false);
+        frame << "unknown expression (internal error)";
+        break;
+    }
+    path = paths.extend(path, frame.str());
+    entry.path = path;
   }
+  return path;
+}
+
+bool EnvI::dumpPath(std::ostream& os, bool force) {
+  PathStore::Path path = currentPath(force);
+  if (path == nullptr) {
+    return false;
+  }
+  PathStore::print(os, path);
   return true;
 }
 
@@ -4604,12 +4685,8 @@ void flatten(Env& e, FlatteningOptions opt) {
               revmap->decl(fi);
               Expression::type(revmap, Type::varbool());
               // Give distinct call stack
-              Annotation& ann = Expression::ann(vdi->e());
-              Expression* tmp = revmap;
-              if (Expression* mznpath_ann = ann.getCall(env.constants.ann.mzn_path)) {
-                tmp = Expression::cast<Call>(mznpath_ann)->arg(0);
-              }
-              CallStackItem csi(env, tmp);
+              CallStackItem csi(env, revmap);
+              env.setPathSplice(get_recorded_path(env, vdi->e()));
               env.flatAddItem(new ConstraintI(Location().introduce(), revmap));
             } else {
               processLast.push_back(i);
@@ -4676,12 +4753,8 @@ void flatten(Env& e, FlatteningOptions opt) {
                   call->type(Type::varbool());
                   call->decl(env.model->matchFn(env, call, false));
                   // Give distinct call stack
-                  Annotation& ann = Expression::ann(vdi->e());
-                  Expression* tmp = call;
-                  if (Expression* mznpath_ann = ann.getCall(env.constants.ann.mzn_path)) {
-                    tmp = Expression::cast<Call>(mznpath_ann)->arg(0);
-                  }
-                  CallStackItem csi(env, tmp);
+                  CallStackItem csi(env, call);
+                  env.setPathSplice(get_recorded_path(env, vdi->e()));
                   env.flatAddItem(new ConstraintI(vdi->loc(), call));
                 }
               } else {
@@ -4736,12 +4809,8 @@ void flatten(Env& e, FlatteningOptions opt) {
               call->type(Type::varbool());
               call->decl(env.model->matchFn(env, call, false));
               // Give distinct call stack
-              Annotation& ann = Expression::ann(vdi->e());
-              Expression* tmp = call;
-              if (Expression* mznpath_ann = ann.getCall(env.constants.ann.mzn_path)) {
-                tmp = Expression::cast<Call>(mznpath_ann)->arg(0);
-              }
-              CallStackItem csi(env, tmp);
+              CallStackItem csi(env, call);
+              env.setPathSplice(get_recorded_path(env, vdi->e()));
               env.flatAddItem(new ConstraintI(vdi->loc(), call));
             }
           }
@@ -5014,25 +5083,27 @@ void flatten(Env& e, FlatteningOptions opt) {
                     Expression::addAnnotation(nc, ee_ann.r());
                   }
                 }
-                StringLit* vsl = get_longest_mzn_path_annotation(env, vdi->e());
-                StringLit* csl = get_longest_mzn_path_annotation(env, c);
+                PathStore::Path vpath = get_recorded_path(env, vdi->e());
+                PathStore::Path cpath = get_recorded_path(env, c);
                 CallStackItem* vsi = nullptr;
                 CallStackItem* csi = nullptr;
-                if (vsl != nullptr) {
-                  vsi = new CallStackItem(env, vsl);
+                if (vpath != nullptr) {
+                  vsi = new CallStackItem(env, vdi->e());
+                  env.setPathSplice(vpath);
                 }
-                if (csl != nullptr) {
-                  csi = new CallStackItem(env, csl);
+                if (cpath != nullptr) {
+                  csi = new CallStackItem(env, c);
+                  env.setPathSplice(cpath);
                 }
                 Location orig_loc = Expression::loc(nc);
-                if (csl != nullptr) {
-                  ASTString loc = csl->v();
-                  size_t sep = loc.find('|');
-                  std::string filename = loc.substr(0, sep);
-                  std::string start_line_s = loc.substr(sep + 1, loc.find('|', sep + 1) - sep - 1);
-                  int start_line = std::stoi(start_line_s);
-                  Location new_loc(ASTString(filename), start_line, 0, start_line, 0);
-                  orig_loc = new_loc;
+                if (const std::string* frame = PathStore::leadingFrame(cpath)) {
+                  // The frame reads "<filename>|<line>|...", the rewritten
+                  // constraint's profiling location.
+                  size_t sep = frame->find('|');
+                  size_t sep2 = frame->find('|', sep + 1);
+                  int start_line = std::stoi(frame->substr(sep + 1, sep2 - sep - 1));
+                  orig_loc =
+                      Location(ASTString(frame->substr(0, sep)), start_line, 0, start_line, 0);
                 }
                 ItemTimer item_timer(orig_loc, timingMap);
                 (void)flat_exp(env, Ctx(), nc, env.constants.varTrue, env.constants.varTrue);
@@ -5140,10 +5211,10 @@ void flatten(Env& e, FlatteningOptions opt) {
                   Expression::addAnnotation(nc, ee_ann.r());
                 }
               }
-              StringLit* sl = get_longest_mzn_path_annotation(env, c);
               CallStackItem* csi = nullptr;
-              if (sl != nullptr) {
-                csi = new CallStackItem(env, sl);
+              if (PathStore::Path p = get_recorded_path(env, c)) {
+                csi = new CallStackItem(env, c);
+                env.setPathSplice(p);
               }
               ItemTimer item_timer(Expression::loc(nc), timingMap);
               (void)flat_exp(env, Ctx(), nc, env.constants.varTrue, env.constants.varTrue);

--- a/lib/flatten.cpp
+++ b/lib/flatten.cpp
@@ -1243,6 +1243,19 @@ void EnvI::copyPathMapsAndState(EnvI& env) {
   varPathStore.maxPathDepth = env.varPathStore.maxPathDepth;
 }
 
+void EnvI::releasePassState() {
+  // Each pass has its own CSE map; only the path state is carried over.
+  _cseMap.clear();
+  // Later passes read variable domains out of this model and nothing else, so
+  // drop the constraints and let the GC reclaim them while those passes run.
+  for (auto& i : *_flat) {
+    if (!i->isa<VarDeclI>()) {
+      i->remove();
+    }
+  }
+  _flat->compact();
+}
+
 void EnvI::flatRemoveExpr(Expression* e, Item* i) {
   std::vector<VarDecl*> toRemove;
   CollectDecls cd(*this, varOccurrences, toRemove, i);

--- a/lib/flatten/flatten_call.cpp
+++ b/lib/flatten/flatten_call.cpp
@@ -1187,7 +1187,6 @@ EE flatten_call(EnvI& env, const Ctx& input_ctx, Expression* e, VarDecl* r, VarD
           } else {
             reif_b = r;
           }
-          // Annotate cr() with get_path()
           add_path_annotation(env, cr());
           reif_b->e(cr());
           if (r != nullptr && r != reif_b) {

--- a/lib/flattener.cpp
+++ b/lib/flattener.cpp
@@ -975,6 +975,57 @@ void Flattener::flatten(const std::string& modelString, const std::string& model
           ss.add("flatTime", flatten_time.s());
         }
 
+        if (_fopts.collectMznPaths) {
+          // Path annotations carry a token while compiling; somebody is about to
+          // read them, so put the text in.
+          class ExpandPathAnnotations : public ItemVisitor {
+          public:
+            explicit ExpandPathAnnotations(const PathStore& paths) : _paths(paths) {}
+            /// Replace mzn_path(<index>) on \a e with mzn_path("<text>").
+            void expandPath(Expression* e) const {
+              Annotation& a = Expression::ann(e);
+              Expression* ann = a.getCall(Constants::constants().ann.mzn_path);
+              if (ann == nullptr) {
+                return;
+              }
+              Expression* arg = Expression::cast<Call>(ann)->arg(0);
+              if (!Expression::isa<IntLit>(arg)) {
+                return;  // already the string variant
+              }
+              auto* idx = Expression::cast<IntLit>(arg);
+              PathStore::Path p = _paths.fromMarkerIndex(IntLit::v(idx));
+              if (p == nullptr) {
+                return;
+              }
+              auto* text = new StringLit(Location(), ASTString(PathStore::toString(p)));
+              Call* expanded =
+                  Call::a(Expression::loc(ann), Constants::constants().ann.mzn_path, {text});
+              Expression::type(expanded, Type::ann());
+              a.removeCall(Constants::constants().ann.mzn_path);
+              Expression::addAnnotation(e, expanded);
+            }
+            void vVarDeclI(VarDeclI* vdi) const { expandPath(vdi->e()); }
+            void vConstraintI(ConstraintI* ci) const {
+              expandPath(ci->e());
+              if (auto* c = Expression::dynamicCast<Call>(ci->e())) {
+                for (int i = 0; i < c->argCount(); i++) {
+                  expandPath(c->arg(i));
+                }
+              }
+            }
+            void vSolveI(SolveI* si) const {
+              if (Expression* e = si->e()) {
+                expandPath(e);
+              }
+            }
+
+          private:
+            const PathStore& _paths;
+          } expandPaths(env->envi().varPathStore.getPaths());
+          GCLock lock;
+          iter_items<ExpandPathAnnotations>(expandPaths, env->flat());
+        }
+
         if (_flags.outputPathsStdout) {
           if (_flags.verbose) {
             _log << "Printing Paths to stdout ..." << std::endl;

--- a/lib/passes/compile_pass.cpp
+++ b/lib/passes/compile_pass.cpp
@@ -144,6 +144,7 @@ Env* CompilePass::run(Env* store, std::ostream& log) {
       return nullptr;
     }
     new_env->envi().copyPathMapsAndState(store->envi());
+    store->envi().releasePassState();
   } else {
     new_env = _env;
   }

--- a/share/minizinc/std/stdlib/stdlib_ann.mzn
+++ b/share/minizinc/std/stdlib/stdlib_ann.mzn
@@ -108,6 +108,10 @@ annotation doc_comment(string: s);
   compilations of a model that may have different names. This annotations is introduced into
   FlatZinc code by the compiler and is retained if --keep-paths argument is used. */
 annotation mzn_path(string: s);
+% Compiler-internal overload standing in for a mzn_path while flattening, where
+% the path text has not been built yet. Always rewritten to the string variant,
+% or removed, before any output is produced.
+annotation mzn_path(int: i);
 /** @group stdlib.annotations.general Used to attach a name \a s to an expression, this should also propagate to
   any sub-expressions or decomposition of the annotated expression. String annotations on expressions
   are re-written as expression_name annotations */


### PR DESCRIPTION
### Description

Two-pass compilation identifies variables between passes by their path, the
flattening call stack written out. That was one string per variable, kilobytes
each because every frame repeats its file name, kept several times over. Paths
are now interned cons cells sharing their common prefix, one pointer each, and
the text is built only for --keep-paths and --output-paths. Fixes #1029:
j90_48_4-wet-diverse-3 did not fit in 32GB at -O3, now compiles in 9GB.

For a smaller instance, `j30_27_5-wet-diverse-3`, where both sides fit:

| | before | after |
|---|---|---|
| `-O2` | 1382 MB / 5.66 s | 347 MB / 2.46 s |
| `-O3` | 431 MB / 2.20 s | 210 MB / 1.90 s |

### Checklist

* [x] Changes are ready for inclusion in next release
* [x] Changelog has been updated, or no changes required
* [x] Test cases changed or added, or no changes required
* [x] Documentation altered, or no changes required
* [x] Pull request(s) opened for required changes to upstream repos, or none required
